### PR TITLE
Add support for CNAME for static picker files

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,7 +2,7 @@
   "root": true,
   "extends": "airbnb-base",
   "globals": {
-    "ENV": false
+    "envGetter": false
   },
   "rules": {
     "arrow-body-style": 0,

--- a/config/env_production.js
+++ b/config/env_production.js
@@ -1,3 +1,9 @@
-export default {
-  picker: 'https://static.filestackapi.com/picker/v3/picker-0.10.8.js',
+const DEFAULT_CNAME = 'filestackapi.com';
+
+const envGetter = (cname) => {
+  return {
+    picker: `https://static.${cname || DEFAULT_CNAME}/picker/v3/picker-0.10.8.js`,
+  };
 };
+
+export default envGetter;

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,6 +3,7 @@ import loader from 'loader';
 
 const init = (apikey, security, cname) => {
   const client = apiClient.init(apikey, security, cname);
+  const env = envGetter(cname);
   return {
     getSecurity() {
       return client.getSecurity();
@@ -15,7 +16,7 @@ const init = (apikey, security, cname) => {
         ...pickOptions,
         cropFiles,
       };
-      return loader.loadModule(ENV.picker, loader.knownModuleIds.picker)
+      return loader.loadModule(env.picker, loader.knownModuleIds.picker)
         .then((pickerConstructor) => {
           return pickerConstructor(client, options);
         });
@@ -25,13 +26,13 @@ const init = (apikey, security, cname) => {
         ...pickOptions,
         dropPane,
       };
-      loader.loadModule(ENV.picker, loader.knownModuleIds.picker)
+      loader.loadModule(env.picker, loader.knownModuleIds.picker)
         .then((pickerConstructor) => {
           pickerConstructor(client, options);
         });
     },
     pick(options) {
-      return loader.loadModule(ENV.picker, loader.knownModuleIds.picker)
+      return loader.loadModule(env.picker, loader.knownModuleIds.picker)
         .then((pickerConstructor) => {
           return pickerConstructor(client, options);
         });

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -42,7 +42,7 @@ export default {
     inject({
       exclude: 'node_modules/**',
       modules: {
-        ENV: jetpack.path(`config/env_${envName}.js`),
+        envGetter: jetpack.path(`config/env_${envName}.js`),
       },
     }),
     nodeResolve({

--- a/rollup_cdn.config.js
+++ b/rollup_cdn.config.js
@@ -32,7 +32,7 @@ export default {
     inject({
       exclude: 'node_modules/**',
       modules: {
-        ENV: jetpack.path(`config/env_${envName}.js`),
+        envGetter: jetpack.path(`config/env_${envName}.js`),
       },
     }),
     nodeResolve(),


### PR DESCRIPTION
Issue is, that when you run .pick with custom CNAME set, everything gets downloaded from your CNAME except for picker-xx.js file, and some additional files downloaded by that library (like main.css).

This fix resolves this, it results in all files being downloaded from the CNAME