### PR TITLE
fix(picker/cname): Load assets from correct cname - picker v1.2.2

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -18,7 +18,7 @@
 /**
  * @private
  */
-const PICKER_VERSION = '1.2.1';
+const PICKER_VERSION = '1.2.2';
 
 /**
  * @private


### PR DESCRIPTION
Fix bug in picker connected with cnames - assets was loading from wrong domain filestackapi.com when cname was provided