### PR TITLE
Changing http to https in readme links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 <p align="center">
-  <a href="https://www.filestack.com"><img src="http://static.filestackapi.com/filestack-js.svg?refresh" align="center" width="250" /></a>  
+  <a href="https://www.filestack.com"><img src="https://static.filestackapi.com/filestack-js.svg?refresh" align="center" width="250" /></a>  
 </p>
 <p align="center">
   <strong>Javascript SDK for the Filestack API and content management system.</strong>
 </p>
 <p align="center">
   <a href="https://npmjs.com/package/filestack-js"><img src="https://img.shields.io/npm/v/filestack-js.svg" /></a>
-  <a href="https://static.filestackapi.com/filestack-js/1.x.x/filestack.min.js"><img src="http://img.badgesize.io/http://static.filestackapi.com/filestack-js/1.x.x/filestack.min.js?compression=gzip&color=green" /></a>
-  <a href="https://static.filestackapi.com/filestack-js/1.x.x/filestack.min.js"><img src="http://img.badgesize.io/http://static.filestackapi.com/filestack-js/1.x.x/filestack.min.js?color=green" /></a>
+  <a href="https://static.filestackapi.com/filestack-js/1.x.x/filestack.min.js"><img src="https://img.badgesize.io/https://static.filestackapi.com/filestack-js/1.x.x/filestack.min.js?compression=gzip&color=green" /></a>
+  <a href="https://static.filestackapi.com/filestack-js/1.x.x/filestack.min.js"><img src="https://img.badgesize.io/https://static.filestackapi.com/filestack-js/1.x.x/filestack.min.js?color=green" /></a>
   <img src="https://img.shields.io/badge/module%20formats-umd%2C%20esm%2C%20cjs-green.svg" />
   <br/>
   <img src="https://badges.herokuapp.com/browsers?labels=none&googlechrome=latest&firefox=latest&microsoftedge=latest&iexplore=11&safari=latest&iphone=latest" />
@@ -66,17 +66,17 @@ The pre-bundled browser module is also available in UMD format. This is useful i
 
 ## Live examples (JSFiddle)
 
-[Upload image](http://jsfiddle.net/gh/get/library/pure/filestack/filestack-js/tree/master/examples/upload)  
-[Open picker](http://jsfiddle.net/gh/get/library/pure/filestack/filestack-js/tree/master/examples/picker)  
-[Open picker in inline mode](http://jsfiddle.net/gh/get/library/pure/filestack/filestack-js/tree/master/examples/picker-inline)  
-[Crop images](http://jsfiddle.net/gh/get/library/pure/filestack/filestack-js/tree/master/examples/crop)  
-[Multiple drop panes](http://jsfiddle.net/gh/get/library/pure/filestack/filestack-js/tree/master/examples/multiple-drop-panes)  
-[Preview](http://jsfiddle.net/gh/get/library/pure/filestack/filestack-js/tree/master/examples/preview)  
-[Import using RequireJS](http://jsfiddle.net/gh/get/library/pure/filestack/filestack-js/tree/master/examples/requirejs)  
-[Retrieve image data](http://jsfiddle.net/gh/get/library/pure/filestack/filestack-js/tree/master/examples/retrieve)  
-[Transform image](http://jsfiddle.net/gh/get/library/pure/filestack/filestack-js/tree/master/examples/transform)  
-[Custom Picker CSS](http://jsfiddle.net/gh/get/library/pure/filestack/filestack-js/tree/master/examples/customization)  
-[Assign file to user](http://jsfiddle.net/gh/get/library/pure/filestack/filestack-js/tree/master/examples/assign-file-to-user)  
+[Upload image](https://jsfiddle.net/gh/get/library/pure/filestack/filestack-js/tree/master/examples/upload)  
+[Open picker](https://jsfiddle.net/gh/get/library/pure/filestack/filestack-js/tree/master/examples/picker)  
+[Open picker in inline mode](https://jsfiddle.net/gh/get/library/pure/filestack/filestack-js/tree/master/examples/picker-inline)  
+[Crop images](https://jsfiddle.net/gh/get/library/pure/filestack/filestack-js/tree/master/examples/crop)  
+[Multiple drop panes](https://jsfiddle.net/gh/get/library/pure/filestack/filestack-js/tree/master/examples/multiple-drop-panes)  
+[Preview](https://jsfiddle.net/gh/get/library/pure/filestack/filestack-js/tree/master/examples/preview)  
+[Import using RequireJS](https://jsfiddle.net/gh/get/library/pure/filestack/filestack-js/tree/master/examples/requirejs)  
+[Retrieve image data](https://jsfiddle.net/gh/get/library/pure/filestack/filestack-js/tree/master/examples/retrieve)  
+[Transform image](https://jsfiddle.net/gh/get/library/pure/filestack/filestack-js/tree/master/examples/transform)  
+[Custom Picker CSS](https://jsfiddle.net/gh/get/library/pure/filestack/filestack-js/tree/master/examples/customization)  
+[Assign file to user](https://jsfiddle.net/gh/get/library/pure/filestack/filestack-js/tree/master/examples/assign-file-to-user)  
 
 Examples can be run locally with: 
 ```


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Docs update

* **What is the current behavior?** (You can also link to an open issue here)

Http links work, but are not taking advantage of the latest best practice on the web.

* **What is the new behavior (if this is a feature change)?**

No change to behavior; only updated links in the README file.

* **Other information**:

I tested each link in my browser to confirm that they are valid and work as before.