### PR TITLE
fix(ie11) downgrade atob lib again

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -362,9 +362,9 @@
       }
     },
     "abab": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.0.tgz",
-      "integrity": "sha512-sY5AXXVZv4Y1VACTtR11UJCPHHudgY5i26Qj5TypE6DKlIApbwb5uqhXcJ5UUGbvZNRh7EeIoW+LrJumBsKp7w=="
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/abab/-/abab-1.0.4.tgz",
+      "integrity": "sha1-X6rZwsB/YN12dw9xzwJbYqY8/U4="
     },
     "abstract-leveldown": {
       "version": "0.12.4",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "node": ">=5.10"
   },
   "dependencies": {
-    "abab": "^2.0.0",
+    "abab": "^1.0.4",
     "ajv": "^6.5.5",
     "file-type": "^8.1.0",
     "filestack-loader": "^3.0.4",


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Downgrade atob lib again to support filestack in ie11

* **What is the current behavior?** (You can also link to an open issue here)

IE11 cannot parse template literals, so filestack.js crashes.

* **What is the new behavior (if this is a feature change)?**

filestack.js runs on IE11

* **Other information**:
