### PR TITLE
make validator static to use it on every Filelink

### DIFF
--- a/src/lib/filelink.ts
+++ b/src/lib/filelink.ts
@@ -445,7 +445,7 @@ export class Filelink {
    * @private
    * @memberof Filelink
    */
-  private validator = getValidator(TransformSchema);
+  private static validator = getValidator(TransformSchema);
 
   /**
    * Applied transforms array
@@ -1207,8 +1207,8 @@ export class Filelink {
     const toValidate = {};
     toValidate[name] = options;
 
-    if (!this.validator(toValidate)) {
-      throw new FilestackError(`Task "${name}" validation error, Params: ${JSON.stringify(options)}`, this.validator.errors);
+    if (!Filelink.validator(toValidate)) {
+      throw new FilestackError(`Task "${name}" validation error, Params: ${JSON.stringify(options)}`, Filelink.validator.errors);
     }
 
     return;


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Improve performance for generating transform url on many handles


* **What is the current behavior?** (You can also link to an open issue here)
[Issue reported](https://github.com/filestack/filestack-js/issues/204)


* **What is the new behavior (if this is a feature change)?**
My suggestion is to use the same validator for all `Filelink` instances


* **Other information**:
