### PR TITLE
fix(base64): Fix b64 url safe creation in filelink

### DIFF
--- a/src/lib/filelink.ts
+++ b/src/lib/filelink.ts
@@ -653,14 +653,14 @@ export class Filelink {
 
     if (this.b64) {
       if (this.transforms.length > 0) {
-        transformsString = `b64/${b64(JSON.stringify(this.transforms))}`;
+        transformsString = `b64/${b64(JSON.stringify(this.transforms), true)}`;
       }
 
       if (Array.isArray(source)) {
         source = this.arrayToString(source);
       }
 
-      source = `b64://${b64(source)}`;
+      source = `b64://${b64(source, true)}`;
     } else {
       if (Array.isArray(source)) {
         source = this.arrayToString(source);

--- a/src/lib/utils/index.spec.ts
+++ b/src/lib/utils/index.spec.ts
@@ -107,6 +107,14 @@ describe('utils:index', () => {
     it('should return correct b65 value', () => {
       expect(b64('testtext')).toEqual('dGVzdHRleHQ=');
     });
+
+    it('should escape chars to make b64 url safe string - char "/"', () => {
+      expect(b64('*0eijATh#"I$PR)s<uTa}{t>E"LC:L', true)).toEqual('KjBlaWpBVGgjIkkkUFIpczx1VGF9e3Q-RSJMQzpM');
+    });
+
+    it('should escape chars to make b64 url safe string - char ""', () => {
+      expect(b64('W{wpB@ckYD0O@&?!||9PS)7^+F*H8N', true)).toEqual('V3t3cEJAY2tZRDBPQCY_IXx8OVBTKTdeK0YqSDhO');
+    });
   });
 
   describe('sanitizeName', () => {

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -164,12 +164,20 @@ export const getMimetype = (file: Uint8Array | Buffer): string => {
  * return based string
  * @param data
  */
-export const b64 = (data: string): string => {
+export const b64 = (data: string, safeUrl: boolean = false): string => {
+  let b64;
+
   if (isNode()) {
-    return Buffer.from(data).toString('base64');
+    b64 = Buffer.from(data).toString('base64');
+  } else {
+    b64 = btoa(data);
   }
 
-  return btoa(data);
+  if (safeUrl) {
+    return b64.replace(/\//g, '_').replace(/\+/g, '-');
+  }
+
+  return b64;
 };
 
 /**


### PR DESCRIPTION
Update b64 to support url-safe string