### PR TITLE
Add unmock to cloud.spec.browser.ts. (#1)

### DIFF
--- a/__unmock__/filestackApi/index.yaml
+++ b/__unmock__/filestackApi/index.yaml
@@ -1,0 +1,211 @@
+openapi: 3.0.0
+info:
+  title: Filestack API
+  version: "1.0"
+
+servers:
+- url: https://cloud.filestackapi.com
+
+paths:
+  /prefetch:
+    options:
+      responses:
+        204:
+          $ref: "#/components/responses/Options"
+    get:
+      summary: Prefetch
+      parameters:
+        - name: apikey
+          in: query
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Prefetch get
+          content:
+            text/plain:
+              schema:
+                type: string
+  /folder/list:
+    post:
+      requestBody:
+        description: "Request body"
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ListRequestBody"
+      responses:
+        200:
+          description: "Post response"
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  token:
+                    type: string
+                    default: ""
+    options:
+      responses:
+        204:
+          $ref: "#/components/responses/Options"
+  /store/:
+    options:
+      responses:
+        204:
+          $ref: "#/components/responses/Options"
+    post:
+      requestBody:
+        description: "Store post request body"
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/StoreRequestBody"
+      responses:
+        200:
+          description: "Store post response"
+          type: object
+          parameters:
+            token:
+              type: string
+              default: ""
+  /auth/logout:
+    options:
+      responses:
+        204:
+          $ref: "#/components/responses/Options"
+    post:
+      requestBody:
+        description: "Logout post request body"
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/LogoutRequestBody"
+      responses:
+        200:
+          description: "Logout post response"
+          type: object
+  /metadata:
+    options:
+      responses:
+        204:
+          $ref: "#/components/responses/Options"
+    post:
+      requestBody:
+        description: "Metadata post request body"
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/MetadataRequestBody"
+      responses:
+        200:
+          description: "Metadata post response"
+          type: object
+  /recording/{media}/init:
+    options:
+      parameters:
+      - in: path
+        name: media
+        required: true
+        schema:
+          type: string
+        enum: [audio, video]
+      responses:
+        204:
+          $ref: "#/components/responses/Options"
+    post:
+      parameters:
+      - in: path
+        name: media
+        required: true
+        schema:
+          type: string
+        enum: [audio, video]
+      responses:
+        200:
+          description: "Recording init response"
+          type: object
+  /recording/{media}/start:
+    options:
+      parameters:
+      - in: path
+        name: media
+        required: true
+        schema:
+          type: string
+        enum: [audio, video]
+      responses:
+        204:
+          $ref: "#/components/responses/Options"
+    post:
+      parameters:
+      - in: path
+        name: media
+        required: true
+        schema:
+          type: string
+        enum: [audio, video]
+      responses:
+        200:
+          description: "Recording init response"
+          type: object
+  /recording/{media}/stop:
+    options:
+      parameters:
+      - in: path
+        name: media
+        required: true
+        schema:
+          type: string
+        enum: [audio, video]
+      responses:
+        204:
+          $ref: "#/components/responses/Options"
+    post:
+      parameters:
+      - in: path
+        name: media
+        required: true
+        schema:
+          type: string
+        enum: [audio, video]
+      responses:
+        200:
+          description: "Recording stop response"
+          type: object
+components:
+  schemas:
+    MetadataRequestBody:
+      type: object
+    LogoutRequestBody:
+      type: object
+    StoreRequestBody:
+      type: object
+    ListRequestBody:
+      type: object
+  responses:
+    Options:
+      description: Options
+      headers:
+        access-control-allow-headers:
+          schema:
+            type: array
+            items:
+              type: string
+            default:
+              - filestack-source
+              - filestack-trace-id
+              - filestack-trace-span
+        access-control-allow-methods:
+          schema:
+            type: string
+            default: "*"
+        access-control-allow-origin:
+          schema:
+            type: string
+            default: "*"
+      content:
+        text/plain:
+          schema:
+            type: string

--- a/package-lock.json
+++ b/package-lock.json
@@ -741,6 +741,25 @@
         "semver": "^5.5.0"
       }
     },
+    "@babel/runtime": {
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.5.5.tgz",
+      "integrity": "sha512-28QvEGyQyNkB0/m2B4FU7IEZGK2NUrcMtT6BZEFALTguLk+AUT6ofsHtPk5QyjAdUkpMJ+/Em+quwz4HOt30AQ==",
+      "dev": true,
+      "requires": {
+        "regenerator-runtime": "^0.13.2"
+      }
+    },
+    "@babel/runtime-corejs2": {
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.5.5.tgz",
+      "integrity": "sha512-FYATQVR00NSNi7mUfpPDp7E8RYMXDuO8gaix7u/w3GekfUinKgX1AcTxs7SoiEmoEW9mbpjrwqWSW6zCmw5h8A==",
+      "dev": true,
+      "requires": {
+        "core-js": "^2.6.5",
+        "regenerator-runtime": "^0.13.2"
+      }
+    },
     "@babel/template": {
       "version": "7.4.4",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.4.tgz",
@@ -2120,6 +2139,12 @@
         }
       }
     },
+    "app-root-path": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/app-root-path/-/app-root-path-2.2.1.tgz",
+      "integrity": "sha512-91IFKeKk7FjfmezPKkwtaRvSpnUc4gDwPAjA1YZ9Gn0q0PPeW+vbeUsZuyDwjI7+QTHhcLen2v25fi/AmhvbJA==",
+      "dev": true
+    },
     "append-buffer": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/append-buffer/-/append-buffer-1.0.2.tgz",
@@ -2639,6 +2664,21 @@
         "tweetnacl": "^0.14.3"
       }
     },
+    "better-ajv-errors": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/better-ajv-errors/-/better-ajv-errors-0.6.4.tgz",
+      "integrity": "sha512-+spBhtcCzovXWeHpt5dGylFsn3p5l9w+KcUqh/b4MFdLV+q1sT1olxD9izvwi0D3WuP06eVgeZAGLtxtTnUIDg==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "@babel/runtime": "^7.0.0",
+        "chalk": "^2.4.1",
+        "core-js": "^2.5.7",
+        "json-to-ast": "^2.0.3",
+        "jsonpointer": "^4.0.1",
+        "leven": "^2.1.0"
+      }
+    },
     "bfj": {
       "version": "6.1.2",
       "resolved": "https://registry.npmjs.org/bfj/-/bfj-6.1.2.tgz",
@@ -3127,6 +3167,12 @@
         "supports-color": "^5.3.0"
       }
     },
+    "charenc": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+      "integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc=",
+      "dev": true
+    },
     "check-error": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
@@ -3403,6 +3449,12 @@
       "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
       "dev": true
     },
+    "code-error-fragment": {
+      "version": "0.0.230",
+      "resolved": "https://registry.npmjs.org/code-error-fragment/-/code-error-fragment-0.0.230.tgz",
+      "integrity": "sha512-cadkfKp6932H8UkhzE/gcUqhRMNf8jHzkAN7+5Myabswaghu4xABTgPHDCjW+dBAJxj/SpkTYokpzDqY4pCzQw==",
+      "dev": true
+    },
     "code-point-at": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
@@ -3443,6 +3495,16 @@
         "object-visit": "^1.0.0"
       }
     },
+    "color": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/color/-/color-3.0.0.tgz",
+      "integrity": "sha512-jCpd5+s0s0t7p3pHQKpnJ0TpQKKdleP71LWcA0aqiljpiuAkOSUFN/dyH8ZwF0hRmFlrIuRhufds1QyEP9EB+w==",
+      "dev": true,
+      "requires": {
+        "color-convert": "^1.9.1",
+        "color-string": "^1.5.2"
+      }
+    },
     "color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -3458,10 +3520,26 @@
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
+    "color-string": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.3.tgz",
+      "integrity": "sha512-dC2C5qeWoYkxki5UAXapdjqO672AM4vZuPGRQfO8b5HKuKGBbKWpITyDYN7TOFKvRW7kOgAn3746clDBMDJyQw==",
+      "dev": true,
+      "requires": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
+    },
     "color-support": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
       "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
+      "dev": true
+    },
+    "colornames": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/colornames/-/colornames-1.1.1.tgz",
+      "integrity": "sha1-+IiQMGhcfE/54qVZ9Qd+t2qBb5Y=",
       "dev": true
     },
     "colors": {
@@ -3469,6 +3547,16 @@
       "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
       "integrity": "sha1-JCP+ZnisDF2uiFLl0OW+CMmXq8w=",
       "dev": true
+    },
+    "colorspace": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.1.2.tgz",
+      "integrity": "sha512-vt+OoIP2d76xLhjwbBaucYlNSpPsrJWPlBTtwCpQKIu6/CSMutyzX93O/Do0qzpH3YoHEes8YEFXyZ797rEhzQ==",
+      "dev": true,
+      "requires": {
+        "color": "3.0.x",
+        "text-hex": "1.0.x"
+      }
     },
     "combined-stream": {
       "version": "1.0.8",
@@ -4481,6 +4569,12 @@
         "is-plain-object": "^2.0.1"
       }
     },
+    "core-js": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.9.tgz",
+      "integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A==",
+      "dev": true
+    },
     "core-js-compat": {
       "version": "3.1.4",
       "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.1.4.tgz",
@@ -4603,6 +4697,12 @@
         }
       }
     },
+    "crypt": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+      "integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs=",
+      "dev": true
+    },
     "crypto-browserify": {
       "version": "3.12.0",
       "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
@@ -4667,6 +4767,12 @@
         "es5-ext": "^0.10.50",
         "type": "^1.0.1"
       }
+    },
+    "dag-map": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/dag-map/-/dag-map-1.0.2.tgz",
+      "integrity": "sha1-6DefBBAA7VYfxRVHXB7SyF7s6Nc=",
+      "dev": true
     },
     "dargs": {
       "version": "4.1.0",
@@ -4965,6 +5071,17 @@
       "integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=",
       "dev": true
     },
+    "diagnostics": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/diagnostics/-/diagnostics-1.1.1.tgz",
+      "integrity": "sha512-8wn1PmdunLJ9Tqbx+Fx/ZEuHfJf4NKSN2ZBj7SJC/OWRWha843+WsTjqMe1B5E3p28jqBlp+mJ2fPVxPyNgYKQ==",
+      "dev": true,
+      "requires": {
+        "colorspace": "1.1.x",
+        "enabled": "1.0.x",
+        "kuler": "1.0.x"
+      }
+    },
     "diff": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
@@ -5060,6 +5177,12 @@
         "find-up": "^3.0.0",
         "minimatch": "^3.0.4"
       }
+    },
+    "drange": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/drange/-/drange-1.1.1.tgz",
+      "integrity": "sha512-pYxfDYpued//QpnLIm4Avk7rsNtAtQkUES2cwAYSvD/wd2pKD71gN2Ebj3e7klzXwjocvE8c5vx/1fxwpqmSxA==",
+      "dev": true
     },
     "duplexer": {
       "version": "0.1.1",
@@ -5162,6 +5285,15 @@
       "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k=",
       "dev": true
     },
+    "enabled": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/enabled/-/enabled-1.0.2.tgz",
+      "integrity": "sha1-ll9lE9LC0cX0ZStkouM5ZGf8L5M=",
+      "dev": true,
+      "requires": {
+        "env-variable": "0.0.x"
+      }
+    },
     "encodeurl": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
@@ -5187,6 +5319,12 @@
         "memory-fs": "^0.4.0",
         "tapable": "^1.0.0"
       }
+    },
+    "env-variable": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/env-variable/-/env-variable-0.0.5.tgz",
+      "integrity": "sha512-zoB603vQReOFvTg5xMl9I1P2PnHsHQQKTEowsKKD7nseUfJq6UWzK+4YtlWUO1nhiQUxe6XMkk+JleSZD1NZFA==",
+      "dev": true
     },
     "envify": {
       "version": "4.1.0",
@@ -5695,6 +5833,12 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
+    "fast-safe-stringify": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.6.tgz",
+      "integrity": "sha512-q8BZ89jjc+mz08rSxROs8VsrBBcn1SIw1kq9NjolL509tkABRk9io01RAjSaEv1Xb2uFLt8VtRiZbGp5H8iDtg==",
+      "dev": true
+    },
     "fastq": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.6.0.tgz",
@@ -5712,6 +5856,12 @@
       "requires": {
         "bser": "^2.0.0"
       }
+    },
+    "fecha": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fecha/-/fecha-2.3.3.tgz",
+      "integrity": "sha512-lUGBnIamTAwk4znq5BcqsDaxSmZ9nDVJaij6NvRt/Tg4R69gERA+otPKbS86ROw9nxVMw2/mp1fnaiWqbs6Sdg==",
+      "dev": true
     },
     "figgy-pudding": {
       "version": "3.5.1",
@@ -6035,6 +6185,12 @@
         "for-in": "^1.0.1"
       }
     },
+    "foreach": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
+      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
+      "dev": true
+    },
     "forever-agent": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
@@ -6052,10 +6208,22 @@
         "mime-types": "^2.1.12"
       }
     },
+    "format-util": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/format-util/-/format-util-1.0.3.tgz",
+      "integrity": "sha1-Ay3KShFiYqEsQ/TD7IVmQWxbLZU=",
+      "dev": true
+    },
     "forwarded": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
       "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=",
+      "dev": true
+    },
+    "fp-ts": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-2.0.5.tgz",
+      "integrity": "sha512-opI5r+rVlpZE7Rhk0YtqsrmxGkbIw0dRNqGca8FEAMMnjomXotG+R9QkLQg20onx7R8qhepAn4CCOP8usma/Xw==",
       "dev": true
     },
     "fragment-cache": {
@@ -6167,7 +6335,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -6188,12 +6357,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -6208,17 +6379,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -6335,7 +6509,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -6347,6 +6522,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -6361,6 +6537,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -6368,12 +6545,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -6392,6 +6571,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -6472,7 +6652,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -6484,6 +6665,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -6569,7 +6751,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -6605,6 +6788,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -6624,6 +6808,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -6667,12 +6852,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -7313,6 +7500,12 @@
       "integrity": "sha512-jpSvDPV4Cq/bgtpndIWbI5hmYxhQGHPC4d4cqBPb4DLniCfhJokdXhwhaDuLBGLQdvvRum/UiX6ECVIPvDXqdg==",
       "dev": true
     },
+    "grapheme-splitter": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
+      "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
+      "dev": true
+    },
     "growly": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
@@ -7672,6 +7865,12 @@
         "sshpk": "^1.7.0"
       }
     },
+    "http2-client": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/http2-client/-/http2-client-1.3.3.tgz",
+      "integrity": "sha512-nUxLymWQ9pzkzTmir24p2RtsgruLmhje7lH3hLX1IpwvyTg77fW+1brenPPP3USAR+rQ36p5sTA/x7sjCJVkAA==",
+      "dev": true
+    },
     "https-browserify": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
@@ -7821,6 +8020,23 @@
       "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
       "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
       "dev": true
+    },
+    "io-ts": {
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/io-ts/-/io-ts-1.10.4.tgz",
+      "integrity": "sha512-b23PteSnYXSONJ6JQXRAlvJhuw8KOtkqa87W4wDtvMrud/DTJd5X+NpOOI+O/zZwVq6v0VLAaJ+1EDViKEuN9g==",
+      "dev": true,
+      "requires": {
+        "fp-ts": "^1.0.0"
+      },
+      "dependencies": {
+        "fp-ts": {
+          "version": "1.19.5",
+          "resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-1.19.5.tgz",
+          "integrity": "sha512-wDNqTimnzs8QqpldiId9OavWK2NptormjXnRJTQecNjzwfyp6P/8s/zG8e4h3ja3oqkKaY72UlTjQYt/1yXf9A==",
+          "dev": true
+        }
+      }
     },
     "ip-regex": {
       "version": "2.1.0",
@@ -8022,6 +8238,32 @@
         }
       }
     },
+    "is-invalid-path": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-invalid-path/-/is-invalid-path-0.1.0.tgz",
+      "integrity": "sha1-MHqFWzzxqTi0TqcNLGEQYFNxTzQ=",
+      "dev": true,
+      "requires": {
+        "is-glob": "^2.0.0"
+      },
+      "dependencies": {
+        "is-extglob": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+          "dev": true
+        },
+        "is-glob": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+          "dev": true,
+          "requires": {
+            "is-extglob": "^1.0.0"
+          }
+        }
+      }
+    },
     "is-negated-glob": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-negated-glob/-/is-negated-glob-1.0.0.tgz",
@@ -8153,6 +8395,15 @@
       "resolved": "https://registry.npmjs.org/is-valid-glob/-/is-valid-glob-1.0.0.tgz",
       "integrity": "sha1-Kb8+/3Ab4tTTFdusw5vDn+j2Aao=",
       "dev": true
+    },
+    "is-valid-path": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-valid-path/-/is-valid-path-0.1.1.tgz",
+      "integrity": "sha1-EQ+f90w39mPh7HkV60UfLbk6yd8=",
+      "dev": true,
+      "requires": {
+        "is-invalid-path": "^0.1.0"
+      }
     },
     "is-windows": {
       "version": "1.0.2",
@@ -9489,11 +9740,58 @@
       "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
       "dev": true
     },
+    "json-pointer": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/json-pointer/-/json-pointer-0.6.0.tgz",
+      "integrity": "sha1-jlAFUKaqxUZKRzN32leqbMIoKNc=",
+      "dev": true,
+      "requires": {
+        "foreach": "^2.0.4"
+      }
+    },
     "json-schema": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
       "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
       "dev": true
+    },
+    "json-schema-deref-sync": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/json-schema-deref-sync/-/json-schema-deref-sync-0.10.1.tgz",
+      "integrity": "sha512-ESkdgGyLg5H0el8VvLe3ss8ANsRH05dPOG19HQ2T4hWG/rD1N6Iei7Xltc8Wwcz4pqc+mGWihP2d4mFWtk7A3A==",
+      "dev": true,
+      "requires": {
+        "clone": "^2.1.2",
+        "dag-map": "~1.0.0",
+        "is-valid-path": "^0.1.1",
+        "lodash": "^4.17.13",
+        "md5": "~2.2.0",
+        "memory-cache": "~0.2.0",
+        "traverse": "~0.6.6",
+        "valid-url": "~1.0.9"
+      }
+    },
+    "json-schema-faker": {
+      "version": "0.5.0-rc17",
+      "resolved": "https://registry.npmjs.org/json-schema-faker/-/json-schema-faker-0.5.0-rc17.tgz",
+      "integrity": "sha512-ZQSLPpnsGiMBuPOHi09cAzhsiIeOcs5im2GAQ2P6XKyWOuetO8eYdYCP/kW7VVU891Ucan0/dl8GYbRA6pf9gw==",
+      "dev": true,
+      "requires": {
+        "json-schema-ref-parser": "^6.0.2",
+        "jsonpath": "^1.0.1",
+        "randexp": "^0.5.3"
+      }
+    },
+    "json-schema-ref-parser": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/json-schema-ref-parser/-/json-schema-ref-parser-6.1.0.tgz",
+      "integrity": "sha512-pXe9H1m6IgIpXmE5JSb8epilNTGsmTb2iPohAXpOdhqGFbQjNeHHsZxU+C8w6T81GZxSPFLeUoqDJmzxx5IGuw==",
+      "dev": true,
+      "requires": {
+        "call-me-maybe": "^1.0.1",
+        "js-yaml": "^3.12.1",
+        "ono": "^4.0.11"
+      }
     },
     "json-schema-traverse": {
       "version": "0.4.1",
@@ -9512,6 +9810,16 @@
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
       "dev": true
+    },
+    "json-to-ast": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/json-to-ast/-/json-to-ast-2.1.0.tgz",
+      "integrity": "sha512-W9Lq347r8tA1DfMvAGn9QNcgYm4Wm7Yc+k8e6vezpMnRT+NHbtlxgNBXRVjXe9YM6eTn6+p/MKOlV/aABJcSnQ==",
+      "dev": true,
+      "requires": {
+        "code-error-fragment": "0.0.230",
+        "grapheme-splitter": "^1.0.4"
+      }
     },
     "json5": {
       "version": "2.1.0",
@@ -9535,6 +9843,37 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
       "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
+      "dev": true
+    },
+    "jsonpath": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/jsonpath/-/jsonpath-1.0.2.tgz",
+      "integrity": "sha512-rmzlgFZiQPc6q4HDyK8s9Qb4oxBnI5sF61y/Co5PV0lc3q2bIuRsNdueVbhoSHdKM4fxeimphOAtfz47yjCfeA==",
+      "dev": true,
+      "requires": {
+        "esprima": "1.2.2",
+        "static-eval": "2.0.2",
+        "underscore": "1.7.0"
+      },
+      "dependencies": {
+        "esprima": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.2.tgz",
+          "integrity": "sha1-dqD9Zvz+FU/SkmZ9wmQBl1CxZXs=",
+          "dev": true
+        },
+        "underscore": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
+          "integrity": "sha1-a7rwh3UA02vjTsqlhODbn+8DUgk=",
+          "dev": true
+        }
+      }
+    },
+    "jsonpointer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
+      "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
       "dev": true
     },
     "jsonschema": {
@@ -9580,6 +9919,15 @@
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
       "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
       "dev": true
+    },
+    "kuler": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/kuler/-/kuler-1.0.1.tgz",
+      "integrity": "sha512-J9nVUucG1p/skKul6DU3PUZrhs0LPulNaeUOox0IyXDi8S4CztTHs1gQphhuZmzXG7VOQSf6NJfKuzteQLv9gQ==",
+      "dev": true,
+      "requires": {
+        "colornames": "^1.1.1"
+      }
     },
     "last-run": {
       "version": "1.1.1",
@@ -9714,6 +10062,20 @@
         }
       }
     },
+    "loas3": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/loas3/-/loas3-0.1.1.tgz",
+      "integrity": "sha512-Gs5gr2WAFvIPxahlWh/8y9dRZUe7v+OQ2NIJvVM58ZTCSULcBZtkgFThHidtEm/q4kDZOLfP5jo9v6r4nbzKpg==",
+      "dev": true,
+      "requires": {
+        "ajv": "^6.10.0",
+        "ajv-errors": "^1.0.1",
+        "ajv-keywords": "^3.4.0",
+        "fp-ts": "^2.0.0",
+        "io-ts": "^1.10.2",
+        "prettier": "^1.18.2"
+      }
+    },
     "locate-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
@@ -9783,6 +10145,33 @@
       "dev": true,
       "requires": {
         "lodash._reinterpolate": "^3.0.0"
+      }
+    },
+    "logform": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/logform/-/logform-2.1.2.tgz",
+      "integrity": "sha512-+lZh4OpERDBLqjiwDLpAWNQu6KMjnlXH2ByZwCuSqVPJletw0kTWJf5CgSNAUKn1KUkv3m2cUz/LK8zyEy7wzQ==",
+      "dev": true,
+      "requires": {
+        "colors": "^1.2.1",
+        "fast-safe-stringify": "^2.0.4",
+        "fecha": "^2.3.3",
+        "ms": "^2.1.1",
+        "triple-beam": "^1.3.0"
+      },
+      "dependencies": {
+        "colors": {
+          "version": "1.3.3",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.3.tgz",
+          "integrity": "sha512-mmGt/1pZqYRjMxB1axhTo16/snVZ5krrKkcmMeVKxzECMMXoCgnvTPp10QgHfcbQZw8Dq2jMNG6je4JlWU0gWg==",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        }
       }
     },
     "loose-envify": {
@@ -10039,6 +10428,25 @@
         }
       }
     },
+    "md5": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/md5/-/md5-2.2.1.tgz",
+      "integrity": "sha1-U6s41f48iJG6RlMp6iP6wFQBJvk=",
+      "dev": true,
+      "requires": {
+        "charenc": "~0.0.1",
+        "crypt": "~0.0.1",
+        "is-buffer": "~1.1.1"
+      },
+      "dependencies": {
+        "is-buffer": {
+          "version": "1.1.6",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+          "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+          "dev": true
+        }
+      }
+    },
     "md5.js": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
@@ -10066,6 +10474,12 @@
         "mimic-fn": "^2.0.0",
         "p-is-promise": "^2.0.0"
       }
+    },
+    "memory-cache": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/memory-cache/-/memory-cache-0.2.0.tgz",
+      "integrity": "sha1-eJCwHVLADI68nVM+H46xfjA0hxo=",
+      "dev": true
     },
     "memory-fs": {
       "version": "0.4.1",
@@ -10353,6 +10767,16 @@
         "through2": "^2.0.0"
       }
     },
+    "mitm": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/mitm/-/mitm-1.7.0.tgz",
+      "integrity": "sha512-O6EjnhSf7dDq+pveB5WlRbaz34cZgQuRfey7RonqsD2QB//eVXniYnH5u8QMB6bG7BUIJofL7UPaopE3iYkKlA==",
+      "dev": true,
+      "requires": {
+        "semver": ">= 5 < 6",
+        "underscore": ">= 1.1.6 < 1.6"
+      }
+    },
     "mixin-deep": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
@@ -10560,6 +10984,15 @@
       "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==",
       "dev": true
     },
+    "node-fetch-h2": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/node-fetch-h2/-/node-fetch-h2-2.3.0.tgz",
+      "integrity": "sha512-ofRW94Ab0T4AOh5Fk8t0h8OBWrmjb0SSB20xh1H8YnPV9EJ+f5AMoYSUQ2zgJ4Iq2HAK0I2l5/Nequ8YzFS3Hg==",
+      "dev": true,
+      "requires": {
+        "http2-client": "^1.2.5"
+      }
+    },
     "node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -10632,6 +11065,23 @@
         "semver": "^5.5.0",
         "shellwords": "^0.1.1",
         "which": "^1.3.0"
+      }
+    },
+    "node-readfiles": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/node-readfiles/-/node-readfiles-0.2.0.tgz",
+      "integrity": "sha1-271K8SE04uY1wkXvk//Pb2BnOl0=",
+      "dev": true,
+      "requires": {
+        "es6-promise": "^3.2.1"
+      },
+      "dependencies": {
+        "es6-promise": {
+          "version": "3.3.1",
+          "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.3.1.tgz",
+          "integrity": "sha1-oIzd6EzNvzTQJ6FFG8kdS80ophM=",
+          "dev": true
+        }
       }
     },
     "node-releases": {
@@ -10711,6 +11161,215 @@
       "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.1.4.tgz",
       "integrity": "sha512-iGfd9Y6SFdTNldEy2L0GUhcarIutFmk+MPWIn9dmj8NMIup03G08uUF2KGbbmv/Ux4RT0VZJoP/sVbWA6d/VIw==",
       "dev": true
+    },
+    "oas-kit-common": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/oas-kit-common/-/oas-kit-common-1.0.7.tgz",
+      "integrity": "sha512-8+P8gBjN9bGfa5HPgyefO78o394PUwHoQjuD4hM0Bpl56BkcxoyW4MpWMPM6ATm+yIIz4qT1igmuVukUtjP/pQ==",
+      "dev": true,
+      "requires": {
+        "safe-json-stringify": "^1.2.0"
+      }
+    },
+    "oas-linter": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/oas-linter/-/oas-linter-3.0.1.tgz",
+      "integrity": "sha512-vk8Pzqq8iZM8V0/8NJMHAbf4CMyAUnLTJPNKwCkFl6g2W7omomL3yPpseNqihwU7KgqwYDTjxJ31qavmYbeDbg==",
+      "dev": true,
+      "requires": {
+        "should": "^13.2.1",
+        "yaml": "^1.3.1"
+      }
+    },
+    "oas-resolver": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/oas-resolver/-/oas-resolver-2.2.5.tgz",
+      "integrity": "sha512-AwARII3hmdXtDAGccvjVsRLked0PNJycIG/koD6lYoGspJjxnQ3a8AmDgp7kHYnG148zusfsl8GM0cfwGmd7EA==",
+      "dev": true,
+      "requires": {
+        "node-fetch-h2": "^2.3.0",
+        "oas-kit-common": "^1.0.7",
+        "reftools": "^1.0.8",
+        "yaml": "^1.3.1",
+        "yargs": "^12.0.5"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "camelcase": {
+          "version": "5.3.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+          "dev": true
+        },
+        "cliui": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
+          "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
+          "dev": true,
+          "requires": {
+            "string-width": "^2.1.1",
+            "strip-ansi": "^4.0.0",
+            "wrap-ansi": "^2.0.0"
+          }
+        },
+        "invert-kv": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
+          "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "lcid": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
+          "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
+          "dev": true,
+          "requires": {
+            "invert-kv": "^2.0.0"
+          }
+        },
+        "os-locale": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
+          "integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
+          "dev": true,
+          "requires": {
+            "execa": "^1.0.0",
+            "lcid": "^2.0.0",
+            "mem": "^4.0.0"
+          }
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        },
+        "which-module": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+          "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+          "dev": true
+        },
+        "yargs": {
+          "version": "12.0.5",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
+          "integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
+          "dev": true,
+          "requires": {
+            "cliui": "^4.0.0",
+            "decamelize": "^1.2.0",
+            "find-up": "^3.0.0",
+            "get-caller-file": "^1.0.1",
+            "os-locale": "^3.0.0",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^2.0.0",
+            "string-width": "^2.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^3.2.1 || ^4.0.0",
+            "yargs-parser": "^11.1.1"
+          }
+        },
+        "yargs-parser": {
+          "version": "11.1.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
+          "integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
+          "dev": true,
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
+          }
+        }
+      }
+    },
+    "oas-schema-walker": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/oas-schema-walker/-/oas-schema-walker-1.1.2.tgz",
+      "integrity": "sha512-Q9xqeUtc17ccP/dpUfARci4kwFFszyJAgR/wbDhrRR/73GqsY5uSmKaIK+RmBqO8J4jVYrrDPjQKvt1IcpQdGw==",
+      "dev": true
+    },
+    "oas-validator": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/oas-validator/-/oas-validator-3.3.1.tgz",
+      "integrity": "sha512-WFKafxpH2KrxHG6drJiJ7M0mzGZER3XDkLtbeX8z9YNR4JvCMDlhQL7J2i+rnCxyVC8riRZGGeZpxQ0000w2HA==",
+      "dev": true,
+      "requires": {
+        "ajv": "^5.5.2",
+        "better-ajv-errors": "^0.5.2",
+        "call-me-maybe": "^1.0.1",
+        "oas-kit-common": "^1.0.7",
+        "oas-linter": "^3.0.1",
+        "oas-resolver": "^2.2.5",
+        "oas-schema-walker": "^1.1.2",
+        "reftools": "^1.0.8",
+        "should": "^13.2.1",
+        "yaml": "^1.3.1"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "5.5.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+          "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+          "dev": true,
+          "requires": {
+            "co": "^4.6.0",
+            "fast-deep-equal": "^1.0.0",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.3.0"
+          }
+        },
+        "better-ajv-errors": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/better-ajv-errors/-/better-ajv-errors-0.5.7.tgz",
+          "integrity": "sha512-O7tpXektKWVwYCH5g6Vs3lKD+sJs7JHh5guapmGJd+RTwxhFZEf4FwvbHBURUnoXsTeFaMvGuhTTmEGiHpNi6w==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "@babel/runtime": "^7.0.0",
+            "chalk": "^2.4.1",
+            "core-js": "^2.5.7",
+            "json-to-ast": "^2.0.3",
+            "jsonpointer": "^4.0.1",
+            "leven": "^2.1.0"
+          }
+        },
+        "fast-deep-equal": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+          "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
+          "dev": true
+        },
+        "json-schema-traverse": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+          "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
+          "dev": true
+        }
+      }
     },
     "oauth-sign": {
       "version": "0.9.0",
@@ -10855,6 +11514,21 @@
       "dev": true,
       "requires": {
         "wrappy": "1"
+      }
+    },
+    "one-time": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/one-time/-/one-time-0.0.4.tgz",
+      "integrity": "sha1-+M33eISCb+Tf+T46nMN7HkSAdC4=",
+      "dev": true
+    },
+    "ono": {
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/ono/-/ono-4.0.11.tgz",
+      "integrity": "sha512-jQ31cORBFE6td25deYeD80wxKBMj+zBmHTrVxnc6CKhx8gho6ipmWM5zj/oeoqioZ99yqBls9Z/9Nss7J26G2g==",
+      "dev": true,
+      "requires": {
+        "format-util": "^1.0.3"
       }
     },
     "open": {
@@ -11958,6 +12632,24 @@
       "integrity": "sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g=",
       "dev": true
     },
+    "randexp": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/randexp/-/randexp-0.5.3.tgz",
+      "integrity": "sha512-U+5l2KrcMNOUPYvazA3h5ekF80FHTUG+87SEAmHZmolh1M+i/WyTCxVzmi+tidIa1tM4BSe8g2Y/D3loWDjj+w==",
+      "dev": true,
+      "requires": {
+        "drange": "^1.0.2",
+        "ret": "^0.2.0"
+      },
+      "dependencies": {
+        "ret": {
+          "version": "0.2.2",
+          "resolved": "https://registry.npmjs.org/ret/-/ret-0.2.2.tgz",
+          "integrity": "sha512-M0b3YWQs7R3Z917WRQy1HHA7Ba7D8hvZg6UE5mLykJxQVE2ju0IXbGlaHPPlkY+WN7wFP+wUMXmBFA0aV6vYGQ==",
+          "dev": true
+        }
+      }
+    },
     "randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -12239,6 +12931,12 @@
         "strip-indent": "^2.0.0"
       }
     },
+    "reftools": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/reftools/-/reftools-1.0.8.tgz",
+      "integrity": "sha512-hERpM8J+L0q8dzKFh/QqcLlKZYmTgzGZM7m8b1ptS66eg4NA/iMPm7GNw3TKZ876ndVjGpiLt0BCIfAWsUgwGg==",
+      "dev": true
+    },
     "regenerate": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.0.tgz",
@@ -12253,6 +12951,12 @@
       "requires": {
         "regenerate": "^1.4.0"
       }
+    },
+    "regenerator-runtime": {
+      "version": "0.13.3",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
+      "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==",
+      "dev": true
     },
     "regenerator-transform": {
       "version": "0.14.0",
@@ -12619,6 +13323,12 @@
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true
     },
+    "safe-json-stringify": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/safe-json-stringify/-/safe-json-stringify-1.2.0.tgz",
+      "integrity": "sha512-gH8eh2nZudPQO6TytOvbxnuhYBOvDBBLW52tz5q6X58lJcd/tkmqFR+5Z9adS8aJtURSXWThWy/xJtJwixErvg==",
+      "dev": true
+    },
     "safe-regex": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
@@ -12965,11 +13675,88 @@
       "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
       "dev": true
     },
+    "shimmer": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
+      "integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw==",
+      "dev": true
+    },
+    "should": {
+      "version": "13.2.3",
+      "resolved": "https://registry.npmjs.org/should/-/should-13.2.3.tgz",
+      "integrity": "sha512-ggLesLtu2xp+ZxI+ysJTmNjh2U0TsC+rQ/pfED9bUZZ4DKefP27D+7YJVVTvKsmjLpIi9jAa7itwDGkDDmt1GQ==",
+      "dev": true,
+      "requires": {
+        "should-equal": "^2.0.0",
+        "should-format": "^3.0.3",
+        "should-type": "^1.4.0",
+        "should-type-adaptors": "^1.0.1",
+        "should-util": "^1.0.0"
+      }
+    },
+    "should-equal": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/should-equal/-/should-equal-2.0.0.tgz",
+      "integrity": "sha512-ZP36TMrK9euEuWQYBig9W55WPC7uo37qzAEmbjHz4gfyuXrEUgF8cUvQVO+w+d3OMfPvSRQJ22lSm8MQJ43LTA==",
+      "dev": true,
+      "requires": {
+        "should-type": "^1.4.0"
+      }
+    },
+    "should-format": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/should-format/-/should-format-3.0.3.tgz",
+      "integrity": "sha1-m/yPdPo5IFxT04w01xcwPidxJPE=",
+      "dev": true,
+      "requires": {
+        "should-type": "^1.3.0",
+        "should-type-adaptors": "^1.0.1"
+      }
+    },
+    "should-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/should-type/-/should-type-1.4.0.tgz",
+      "integrity": "sha1-B1bYzoRt/QmEOmlHcZ36DUz/XPM=",
+      "dev": true
+    },
+    "should-type-adaptors": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/should-type-adaptors/-/should-type-adaptors-1.1.0.tgz",
+      "integrity": "sha512-JA4hdoLnN+kebEp2Vs8eBe9g7uy0zbRo+RMcU0EsNy+R+k049Ki+N5tT5Jagst2g7EAja+euFuoXFCa8vIklfA==",
+      "dev": true,
+      "requires": {
+        "should-type": "^1.3.0",
+        "should-util": "^1.0.0"
+      }
+    },
+    "should-util": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/should-util/-/should-util-1.0.1.tgz",
+      "integrity": "sha512-oXF8tfxx5cDk8r2kYqlkUJzZpDBqVY/II2WhvU0n9Y3XYvAYRmeaf1PvvIvTgPnv4KJ+ES5M0PyDq5Jp+Ygy2g==",
+      "dev": true
+    },
     "signal-exit": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
       "dev": true
+    },
+    "simple-swizzle": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+      "integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
+      "dev": true,
+      "requires": {
+        "is-arrayish": "^0.3.1"
+      },
+      "dependencies": {
+        "is-arrayish": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+          "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
+          "dev": true
+        }
+      }
     },
     "sisteransi": {
       "version": "1.0.2",
@@ -13464,6 +14251,15 @@
         }
       }
     },
+    "static-eval": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/static-eval/-/static-eval-2.0.2.tgz",
+      "integrity": "sha512-N/D219Hcr2bPjLxPiV+TQE++Tsmrady7TqAJugLy7Xk1EumfDWS/f5dtBbkRCGE7wKKXuYockQoj8Rm2/pVKyg==",
+      "dev": true,
+      "requires": {
+        "escodegen": "^1.8.1"
+      }
+    },
     "static-extend": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
@@ -13678,6 +14474,137 @@
       "requires": {
         "es6-iterator": "^2.0.1",
         "es6-symbol": "^3.1.1"
+      }
+    },
+    "swagger2openapi": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/swagger2openapi/-/swagger2openapi-5.3.1.tgz",
+      "integrity": "sha512-2EIs1gJs9LH4NjrxHPJs6N0Kh9pg66He+H9gIcfn1Q9dvdqPPVTC2NRdXalqT+98rIoV9kSfAtNBD4ASC0Q1mg==",
+      "dev": true,
+      "requires": {
+        "better-ajv-errors": "^0.6.1",
+        "call-me-maybe": "^1.0.1",
+        "node-fetch-h2": "^2.3.0",
+        "node-readfiles": "^0.2.0",
+        "oas-kit-common": "^1.0.7",
+        "oas-resolver": "^2.2.5",
+        "oas-schema-walker": "^1.1.2",
+        "oas-validator": "^3.3.1",
+        "reftools": "^1.0.8",
+        "yaml": "^1.3.1",
+        "yargs": "^12.0.5"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "camelcase": {
+          "version": "5.3.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+          "dev": true
+        },
+        "cliui": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
+          "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
+          "dev": true,
+          "requires": {
+            "string-width": "^2.1.1",
+            "strip-ansi": "^4.0.0",
+            "wrap-ansi": "^2.0.0"
+          }
+        },
+        "invert-kv": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
+          "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "lcid": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
+          "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
+          "dev": true,
+          "requires": {
+            "invert-kv": "^2.0.0"
+          }
+        },
+        "os-locale": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
+          "integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
+          "dev": true,
+          "requires": {
+            "execa": "^1.0.0",
+            "lcid": "^2.0.0",
+            "mem": "^4.0.0"
+          }
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        },
+        "which-module": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+          "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+          "dev": true
+        },
+        "yargs": {
+          "version": "12.0.5",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
+          "integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
+          "dev": true,
+          "requires": {
+            "cliui": "^4.0.0",
+            "decamelize": "^1.2.0",
+            "find-up": "^3.0.0",
+            "get-caller-file": "^1.0.1",
+            "os-locale": "^3.0.0",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^2.0.0",
+            "string-width": "^2.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^3.2.1 || ^4.0.0",
+            "yargs-parser": "^11.1.1"
+          }
+        },
+        "yargs-parser": {
+          "version": "11.1.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
+          "integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
+          "dev": true,
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
+          }
+        }
       }
     },
     "symbol-tree": {
@@ -13937,6 +14864,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/text-extensions/-/text-extensions-2.0.0.tgz",
       "integrity": "sha512-F91ZqLgvi1E0PdvmxMgp+gcf6q8fMH7mhdwWfzXnl1k+GbpQDmi8l7DzLC5JTASKbwpY3TfxajAUzAXcv2NmsQ==",
+      "dev": true
+    },
+    "text-hex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
+      "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==",
       "dev": true
     },
     "textextensions": {
@@ -14299,6 +15232,12 @@
         }
       }
     },
+    "traverse": {
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
+      "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc=",
+      "dev": true
+    },
     "trim-newlines": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-2.0.0.tgz",
@@ -14324,6 +15263,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
       "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
+      "dev": true
+    },
+    "triple-beam": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.3.0.tgz",
+      "integrity": "sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw==",
       "dev": true
     },
     "tryer": {
@@ -14582,6 +15527,12 @@
       "integrity": "sha1-5z3T17DXxe2G+6xrCufYxqadUPo=",
       "dev": true
     },
+    "underscore": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.5.2.tgz",
+      "integrity": "sha1-EzXF5PXm0zu7SwBrqMhqAPVW3gg=",
+      "dev": true
+    },
     "undertaker": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/undertaker/-/undertaker-1.2.1.tgz",
@@ -14687,6 +15638,63 @@
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
       "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
       "dev": true
+    },
+    "unmock-core": {
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/unmock-core/-/unmock-core-0.1.10.tgz",
+      "integrity": "sha512-4NAiMi4azYnQ+Wfp/1hfyktQcZNFBYuscsej1ghnTlrxV2dI40cacxiME8Y1u6lJWJs2ignY9W3C/VH7SGohDQ==",
+      "dev": true,
+      "requires": {
+        "ajv": "^6.10.0",
+        "axios": "^0.18.0",
+        "boxen": "3.2.0",
+        "chalk": "^2.4.2",
+        "debug": "^4.1.1",
+        "js-yaml": "^3.13.1",
+        "json-pointer": "^0.6.0",
+        "json-schema-deref-sync": "^0.10.1",
+        "json-schema-faker": "^0.5.0-rc17",
+        "loas3": "^0.1.1",
+        "lodash": "^4.17.14",
+        "minimatch": "^3.0.4",
+        "querystring": "^0.2.0",
+        "swagger2openapi": "^5.3.0",
+        "xregexp": "^4.2.4"
+      }
+    },
+    "unmock-node": {
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/unmock-node/-/unmock-node-0.1.10.tgz",
+      "integrity": "sha512-CGc/skAWrjByaI6Ou0EtoWT06fzrSbgbsIKC9WrCb/lxwNHhxCoDbzbAsw5+ye8qs8VJXQGOqjKmhGmw+xY74g==",
+      "dev": true,
+      "requires": {
+        "app-root-path": "^2.2.1",
+        "debug": "^4.1.1",
+        "expect": "^24.7.1",
+        "ini": "^1.3.5",
+        "js-yaml": "^3.13.1",
+        "lodash": "^4.17.14",
+        "mitm": "^1.7.0",
+        "mkdirp": "^0.5.1",
+        "readable-stream": "^3.4.0",
+        "shimmer": "^1.2.1",
+        "unmock-core": "^0.1.10",
+        "uuid": "^3.3.2",
+        "winston": "^3.2.1"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+          "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
+      }
     },
     "unpipe": {
       "version": "1.0.0",
@@ -14898,6 +15906,12 @@
       "requires": {
         "homedir-polyfill": "^1.0.1"
       }
+    },
+    "valid-url": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/valid-url/-/valid-url-1.0.9.tgz",
+      "integrity": "sha1-HBRHm0DxOXp1eC8RXkCGRHQzogA=",
+      "dev": true
     },
     "validate-commit-msg": {
       "version": "2.14.0",
@@ -15550,6 +16564,46 @@
         }
       }
     },
+    "winston": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-3.2.1.tgz",
+      "integrity": "sha512-zU6vgnS9dAWCEKg/QYigd6cgMVVNwyTzKs81XZtTFuRwJOcDdBg7AU0mXVyNbs7O5RH2zdv+BdNZUlx7mXPuOw==",
+      "dev": true,
+      "requires": {
+        "async": "^2.6.1",
+        "diagnostics": "^1.1.1",
+        "is-stream": "^1.1.0",
+        "logform": "^2.1.1",
+        "one-time": "0.0.4",
+        "readable-stream": "^3.1.1",
+        "stack-trace": "0.0.x",
+        "triple-beam": "^1.3.0",
+        "winston-transport": "^4.3.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+          "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
+      }
+    },
+    "winston-transport": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.3.0.tgz",
+      "integrity": "sha512-B2wPuwUi3vhzn/51Uukcao4dIduEiPOcOt9HJ3QeaXgkJ5Z7UwpBzxS4ZGNHtrxrUvTwemsQiSys0ihOf8Mp1A==",
+      "dev": true,
+      "requires": {
+        "readable-stream": "^2.3.6",
+        "triple-beam": "^1.2.0"
+      }
+    },
     "wordwrap": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
@@ -15659,6 +16713,15 @@
       "integrity": "sha512-7hew1RPJ1iIuje/Y01bGD/mXokXxegAgVS+e+E0wSi2ILHQkYAH1+JXARwTjZSM4Z4Z+c73aKspEcqj+zPPL/w==",
       "dev": true
     },
+    "xregexp": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/xregexp/-/xregexp-4.2.4.tgz",
+      "integrity": "sha512-sO0bYdYeJAJBcJA8g7MJJX7UrOZIfJPd8U2SC7B2Dd/J24U0aQNoGp33shCaBSWeb0rD5rh6VBUIXOkGal1TZA==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime-corejs2": "^7.2.0"
+      }
+    },
     "xtend": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
@@ -15676,6 +16739,15 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
       "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
       "dev": true
+    },
+    "yaml": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.6.0.tgz",
+      "integrity": "sha512-iZfse3lwrJRoSlfs/9KQ9iIXxs9++RvBFVzAqbbBiFT+giYtyanevreF9r61ZTbGMgWQBxAua3FzJiniiJXWWw==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.4.5"
+      }
     },
     "yargs": {
       "version": "7.1.0",

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "tslint-config-semistandard": "^8.0.1",
     "typedoc": "^0.14.2",
     "typescript": "^3.5.3",
+    "unmock-node": "^0.1.10",
     "validate-commit-msg": "^2.14.0",
     "webpack": "^4.35.3",
     "webpack-assets-manifest": "^3.1.1",

--- a/src/lib/api/cloud.spec.browser.ts
+++ b/src/lib/api/cloud.spec.browser.ts
@@ -17,7 +17,7 @@
 
 import { config } from './../../config';
 import { CloudClient, PICKER_KEY } from './cloud';
-import * as nock from 'nock';
+import unmock, { States } from 'unmock-node';
 
 const testApiKey = 'API_KEY';
 const testTokSession = 'TOK_SESSION';
@@ -36,178 +36,129 @@ const testSession = {
   urls: sessionURls,
 };
 
-let scope = nock(sessionURls.cloudApiUrl);
-
-const mockTokInit = jest
-  .fn()
-  .mockName('tokInit')
-  .mockReturnValue('init');
-
-const mockTokStart = jest
-  .fn()
-  .mockName('tokStart')
-  .mockReturnValue('start');
-
-const mockTokStop = jest
-  .fn()
-  .mockName('tokStop')
-  .mockReturnValue('stop');
-
-const mockMetadata = jest
-  .fn()
-  .mockName('metadata')
-  .mockReturnValue('metadata');
-
-const mockPrefetch = jest
-  .fn()
-  .mockName('prefetch')
-  .mockReturnValue('prefetch');
-
-const mockList = jest
-  .fn()
-  .mockName('list')
-  .mockImplementation(data => {
-    if (data && data.clouds.token) {
-      return { token: testCloudToken };
-    }
-
-    return data;
-  });
-
-const mockLogout = jest
-  .fn()
-  .mockName('logout')
-  .mockImplementation((url, data) => {
-    const params = data ? JSON.parse(data) : {};
-
-    if (data && params.clouds && params.clouds.token) {
-      return { token: testCloudToken };
-    }
-
-    return data;
-  });
-
-const mockStore = jest
-  .fn()
-  .mockName('store')
-  .mockImplementation(params => {
-    if (params && params.clouds && params.clouds.token) {
-      return JSON.stringify({ token: testCloudToken });
-    }
-
-    return JSON.stringify(params);
-  });
-
 describe('cloud', () => {
+  let states: States;
+  beforeAll(() => {
+    states = unmock.on();
+  });
   beforeEach(() => {
-    scope
-      .persist()
-      .options(/.*/)
-      .reply(204, '', {
-        'access-control-allow-headers': 'filestack-source,filestack-trace-id,filestack-trace-span',
-        'access-control-allow-methods': '*',
-        'access-control-allow-origin': '*',
-      });
-
-    scope
-      .get('/prefetch')
-      .query({ apikey: testApiKey })
-      .reply(200, mockPrefetch);
-
-    scope.post('/auth/logout').reply(200, mockLogout);
-    scope.post('/folder/list').reply(200, (_, data) => mockList(JSON.parse(data)));
-    scope.post('/store/').reply(200, (_, data) => mockStore(JSON.parse(data)));
-    scope.post('/metadata').reply(200, mockMetadata);
-
-    scope.post(/\/recording\/(audio|video)\/init/).reply(200, mockTokInit);
-    scope.post(/\/recording\/(audio|video)\/start/).reply(200, mockTokStart);
-    scope.post(/\/recording\/(audio|video)\/stop/).reply(200, mockTokStop);
+    states.reset();
   });
 
   afterEach(() => {
-    nock.cleanAll();
     jest.clearAllMocks();
     localStorage.clear();
   });
 
+  afterAll(() => {
+    unmock.off();
+  });
+
   describe('prefetch', () => {
     it('should make correct request to api', async () => {
+      const expectedPrefetchResponse = 'prefetch';
+      const mockPrefetchGet = jest.fn().mockImplementationOnce(() => expectedPrefetchResponse);
+      states.filestackApi.get('/prefetch', mockPrefetchGet);
+
       const res = await new CloudClient(testSession).prefetch();
 
-      expect(mockPrefetch).toHaveBeenCalledWith(expect.any(String), '');
-      expect(res).toEqual('prefetch');
+      const expectedRequest = { body: undefined, method: 'GET' };
+      expect(mockPrefetchGet)
+        .toHaveBeenCalledWith(
+          expect.objectContaining(expectedRequest),
+          expect.anything()
+        );
+      expect(res).toEqual(expectedPrefetchResponse);
     });
   });
 
   describe('list', () => {
+    const expectedRequestBase = { apikey: testApiKey, clouds: { test: true }, flow: 'web' };
+    beforeEach(() => states.reset());
     it('should make correct list request', async () => {
       const clouds = { test: true };
-
-      const res = await new CloudClient(testSession).list({ ...clouds });
-
-      expect(res).toEqual({
-        apikey: testApiKey,
-        flow: 'web',
-        clouds,
+      const mockFolderListPost = jest.fn().mockImplementationOnce(_ => {
+        return { token: testCloudToken };
       });
+      states.filestackApi.post('/folder/list', mockFolderListPost);
+      await new CloudClient(testSession).list({ ...clouds });
+
+      expect(mockFolderListPost)
+        .toHaveBeenCalledWith(
+          expect.objectContaining({ body: expectedRequestBase }), expect.anything()
+        );
     });
 
     it('should make correct list request with session cache', async () => {
       const clouds = { test: true };
       localStorage.setItem(PICKER_KEY, testCloudToken);
 
-      const res = await new CloudClient(testSession, {
+      const mockFolderListPost = jest.fn().mockImplementationOnce(() => {
+        return { token: testCloudToken };
+      });
+      states.filestackApi.post('/folder/list', mockFolderListPost);
+
+      await new CloudClient(testSession, {
         sessionCache: true,
       }).list({ ...clouds });
 
-      expect(res).toEqual({
-        apikey: testApiKey,
-        flow: 'web',
-        token: testCloudToken,
-        clouds,
-      });
+      expect(mockFolderListPost)
+        .toHaveBeenCalledWith(
+          expect.objectContaining(
+            { body: { ...expectedRequestBase, token: testCloudToken } }
+          ),
+          expect.anything()
+        );
     });
 
     it('should set token on api token response', async () => {
       const clouds = { token: true };
+      states.filestackApi.post('/folder/list', { token: testCloudToken });
       const res = await new CloudClient(testSession).list({ ...clouds });
 
-      expect(res).toEqual({ token: testCloudToken });
+      expect(res).toHaveProperty('token', testCloudToken);
     });
 
     it('should cache session token to local storage', async () => {
       const clouds = { token: true };
-
-      const res = await new CloudClient(testSession, { sessionCache: true }).list({ ...clouds });
+      states.filestackApi.post('/folder/list', { token: testCloudToken });
+      await new CloudClient(testSession, { sessionCache: true }).list({ ...clouds });
 
       expect(localStorage.setItem).toHaveBeenCalledWith(PICKER_KEY, testCloudToken);
-      expect(res).toEqual({ token: testCloudToken });
     });
 
     it('should make correct list request with security', async () => {
       const clouds = { test: true };
 
-      const res = await new CloudClient({
+      const mockFolderListPost = jest.fn().mockImplementationOnce(() => {
+        return { token: testCloudToken };
+      });
+      states.filestackApi.post('/folder/list', mockFolderListPost);
+
+      await new CloudClient({
         ...testSession,
         ...testSecurity,
       }).list({ ...clouds });
 
-      expect(res).toEqual({
-        apikey: testApiKey,
-        flow: 'web',
-        clouds,
-        ...testSecurity,
-      });
+      const expectedRequestBody = { ...expectedRequestBase, ...testSecurity };
+
+      expect(mockFolderListPost)
+        .toHaveBeenCalledWith(
+          expect.objectContaining({ body: expectedRequestBody }),
+          expect.anything()
+        );
     });
   });
 
   describe('store', () => {
-    it('should make correct basic request', async () => {
-      const res = await new CloudClient(testSession).store('google', 'test', { filename: '1' });
+    const expectedRequestBase = { apikey: testApiKey, flow: 'web' };
+    it('store should make correct basic request', async () => {
+      const mockStorePost = jest.fn().mockImplementationOnce(() => ({ message: 'Boo' }));
+      states.filestackApi.post('/store/', mockStorePost);
+      await new CloudClient(testSession).store('google', 'test', { filename: '1' });
 
-      expect(res).toEqual({
-        apikey: testApiKey,
-        flow: 'web',
+      const expectedRequest = {
+        ...expectedRequestBase,
         clouds: {
           google: {
             path: 'test',
@@ -217,15 +168,22 @@ describe('cloud', () => {
             },
           },
         },
-      });
+      };
+
+      expect(mockStorePost)
+        .toHaveBeenCalledWith(
+          expect.objectContaining({ body: expectedRequest }), expect.anything()
+        );
     });
 
     it('should respect store location param', async () => {
-      const res = await new CloudClient(testSession).store('google', 'test', { filename: '1', location: 'gcs' });
+      const mockStorePost = jest.fn().mockImplementationOnce(() => ({ message: 'Boo' }));
+      states.filestackApi.post('/store/', mockStorePost);
 
-      expect(res).toEqual({
-        apikey: testApiKey,
-        flow: 'web',
+      await new CloudClient(testSession).store('google', 'test', { filename: '1', location: 'gcs' });
+
+      const expectedRequest = {
+        ...expectedRequestBase,
         clouds: {
           google: {
             path: 'test',
@@ -235,19 +193,25 @@ describe('cloud', () => {
             },
           },
         },
-      });
+      };
+
+      expect(mockStorePost)
+        .toHaveBeenCalledWith(
+          expect.objectContaining({ body: expectedRequest }), expect.anything()
+        );
     });
 
-    it('should make correct basic with security', async () => {
-      const res = await new CloudClient({
+    it('should make correct basic request with security', async () => {
+      const mockStorePost = jest.fn().mockImplementationOnce(() => ({ message: 'Boo' }));
+      states.filestackApi.post('/store/', mockStorePost);
+
+      await new CloudClient({
         ...testSession,
         ...testSecurity,
       }).store('token', 'test', { filename: '1' });
 
-      const excepted = {
-        ...testSecurity,
-        apikey: testApiKey,
-        flow: 'web',
+      const expectedRequest = {
+        ...expectedRequestBase,
         clouds: {
           token: {
             path: 'test',
@@ -257,23 +221,27 @@ describe('cloud', () => {
             },
           },
         },
+        ...testSecurity,
       };
 
-      expect(mockStore).toHaveBeenCalledWith(excepted);
-      expect(res).toEqual(testCloudToken);
+      expect(mockStorePost)
+        .toHaveBeenCalledWith(
+          expect.objectContaining({ body: expectedRequest }), expect.anything());
     });
 
     it('should handle custom source', async () => {
+      const mockStorePost = jest.fn().mockImplementationOnce(() => ({ message: 'Boo' }));
+      states.filestackApi.post('/store/', mockStorePost);
+
       const customSource = {
         customSourcePath: 'cs_path',
         customSourceContainer: 'cs_container',
       };
 
-      const res = await new CloudClient(testSession).store('customsource', 'test', { filename: '1' }, customSource);
+      await new CloudClient(testSession).store('customsource', 'test', { filename: '1' }, customSource);
 
-      expect(res).toEqual({
-        apikey: testApiKey,
-        flow: 'web',
+      const expectedRequest = {
+        ...expectedRequestBase,
         clouds: {
           customsource: {
             ...customSource,
@@ -284,147 +252,207 @@ describe('cloud', () => {
             },
           },
         },
-      });
+      };
+      expect(mockStorePost)
+        .toHaveBeenCalledWith(
+          expect.objectContaining({ body: expectedRequest }), expect.anything()
+        );
     });
   });
 
   describe('logout', () => {
+    const expectedRequestBase = { apikey: testApiKey, flow: 'web' };
     it('should make correct request to logout', async () => {
-      expect(await new CloudClient(testSession).logout()).toEqual({ apikey: 'API_KEY', flow: 'web' });
+      const mockLogoutPost = jest.fn();
+      states.filestackApi.post('/auth/logout', mockLogoutPost);
+      await new CloudClient(testSession).logout();
+      expect(mockLogoutPost)
+        .toHaveBeenCalledWith(
+          expect.objectContaining({ body: expectedRequestBase }),
+          expect.anything()
+        );
     });
 
     it('should make correct request to logout with provided cloud', async () => {
-      expect(await new CloudClient(testSession).logout('google')).toEqual({ apikey: 'API_KEY', flow: 'web', clouds: { google: {} } });
+      const mockLogoutPost = jest.fn();
+      states.filestackApi.post('/auth/logout', mockLogoutPost);
+      await new CloudClient(testSession).logout('google');
+      expect(mockLogoutPost)
+        .toHaveBeenCalledWith(
+          expect.objectContaining({ body: { ...expectedRequestBase, clouds: { google: {} } } }),
+          expect.anything()
+        );
     });
 
     it('should make correct request to logout and return correct response when cloud name is returned', async () => {
-      expect(await new CloudClient(testSession).logout('token')).toEqual('testCloudToken');
+      const mockLogoutPost = jest.fn().mockImplementationOnce(() => ({ token: testCloudToken }));
+      states.filestackApi.post('/auth/logout', mockLogoutPost);
+      const res = await new CloudClient(testSession).logout('token');
+      expect(res).toEqual(testCloudToken);
     });
 
     it('should make correct request to logout and clean session cache ', async () => {
       localStorage.setItem(PICKER_KEY, testCloudToken);
 
-      const res = await new CloudClient(testSession, { sessionCache: true }).logout();
+      const mockLogoutPost = jest.fn();
+      states.filestackApi.post('/auth/logout', mockLogoutPost);
+
+      await new CloudClient(testSession, { sessionCache: true }).logout();
 
       expect(localStorage.removeItem).toHaveBeenCalledWith(PICKER_KEY);
-      expect(res).toEqual({ apikey: 'API_KEY', flow: 'web', token: testCloudToken });
+      expect(mockLogoutPost)
+        .toHaveBeenCalledWith(
+          expect.objectContaining({
+            body: { ...expectedRequestBase, token: testCloudToken },
+          }),
+          expect.anything()
+        );
     });
   });
 
   describe('metadata', () => {
+    const testUrl = 'http://test.com';
+    const expectedRequestBase = { apikey: testApiKey, url: testUrl };
     it('should make correct request', async () => {
-      const testUrl = 'http://test.com';
-
+      const mockMetadataPost = jest.fn().mockImplementationOnce(() => 'metadata');
+      states.filestackApi.post('/metadata', mockMetadataPost);
       const res = await new CloudClient(testSession).metadata(testUrl);
 
-      expect(mockMetadata).toHaveBeenCalledWith(
-        expect.any(String),
-        JSON.stringify({
-          apikey: testApiKey,
-          url: testUrl,
-        })
-      );
-      expect(res).toEqual('metadata');
+      expect(mockMetadataPost)
+        .toHaveBeenCalledWith(
+          expect.objectContaining({
+            body: expectedRequestBase,
+          }),
+          expect.anything()
+        );
+      expect(res).toBe('metadata');
     });
 
     it('should make correct request with security', async () => {
-      const testUrl = 'http://test.com';
 
-      const res = await new CloudClient({
+      const mockMetadataPost = jest.fn().mockImplementationOnce(() => 'metadata');
+      states.filestackApi.post('/metadata', mockMetadataPost);
+
+      await new CloudClient({
         ...testSession,
         ...testSecurity,
       }).metadata(testUrl);
 
-      expect(mockMetadata).toHaveBeenCalledWith(
-        expect.any(String),
-        JSON.stringify({
-          apikey: testApiKey,
-          url: testUrl,
-          ...testSecurity,
-        })
-      );
-      expect(res).toEqual('metadata');
+      expect(mockMetadataPost)
+        .toHaveBeenCalledWith(
+          expect.objectContaining({
+            body: { ...expectedRequestBase, ...testSecurity },
+          }),
+          expect.anything()
+     );
     });
   });
 
   describe('OpenTok', () => {
     describe('tokInit', () => {
-      it('should make correct request to api (audio)', async () => {
+      it('should make correct request to api audio', async () => {
+        const mockTokInit = jest.fn().mockImplementationOnce(() => 'init');
+        states.filestackApi.post('/recording/audio/init', mockTokInit);
         const res = await new CloudClient(testSession).tokInit('audio');
 
-        expect(mockTokInit).toHaveBeenCalledWith(expect.any(String), '');
-        expect(res).toEqual('init');
+        expect(mockTokInit)
+          .toHaveBeenCalledWith(
+            expect.objectContaining({
+              body: undefined,
+            }),
+            expect.anything()
+          );
+        expect(res).toEqual({ body: 'init' });
       });
 
-      it('should make correct request to api (video)', async () => {
-        const res = await new CloudClient(testSession).tokInit('audio');
+      it('should make correct request to api video', async () => {
+        const mockTokInit = jest.fn();
+        states.filestackApi.post('/recording/video/init', mockTokInit);
 
-        expect(mockTokInit).toHaveBeenCalledWith(expect.any(String), '');
-        expect(res).toEqual('init');
+        await new CloudClient(testSession).tokInit('video');
+
+        expect(mockTokInit)
+          .toHaveBeenCalledWith(
+            expect.objectContaining({
+              body: undefined,
+            }),
+            expect.anything()
+          );
       });
 
-      it('should throw on wrong type', async() => {
-        expect(() => {
-          new CloudClient(testSession).tokInit('videoa').then(() => {
-            console.log('init');
-          }).catch(() => {
-            console.log('err');
-          });
-        }).toThrowError();
+      it('tokInit should throw on wrong type', async () => {
+        expect(() =>
+          new CloudClient(testSession)
+            .tokInit('videoa')
+        ).toThrowError('Type must be');
       });
     });
 
     describe('tokStart', () => {
-      it('should make correct request to api (audio)', async () => {
-        const res = await new CloudClient(testSession).tokStart('audio', 'key', testTokSession);
-
-        expect(mockTokStart).toHaveBeenCalledWith(expect.any(String), JSON.stringify({ apikey: 'key', session_id: testTokSession }));
-        expect(res).toEqual('start');
+      const expectedRequest = { apikey: testApiKey, session_id: testTokSession };
+      it('should make correct request to api audio', async () => {
+        const mockTokStart = jest.fn().mockImplementationOnce(() => 'start');
+        states.filestackApi.post('/recording/audio/start', mockTokStart);
+        const res = await new CloudClient(testSession).tokStart('audio', testApiKey, testTokSession);
+        expect(mockTokStart)
+          .toHaveBeenCalledWith(
+            expect.objectContaining({
+              body: expectedRequest,
+            }),
+            expect.anything());
+        expect(res).toEqual({ body: 'start' });
       });
 
-      it('should make correct request to api (video)', async () => {
-        const res = await new CloudClient(testSession).tokStart('video', 'key', testTokSession);
+      it('should make correct request to api video', async () => {
+        const mockTokStart = jest.fn();
+        states.filestackApi.post('/recording/video/start', mockTokStart);
+        await new CloudClient(testSession).tokStart('video', testApiKey, testTokSession);
 
-        expect(mockTokStart).toHaveBeenCalledWith(expect.any(String), JSON.stringify({ apikey: 'key', session_id: testTokSession }));
-        expect(res).toEqual('start');
+        expect(mockTokStart)
+          .toHaveBeenCalledWith(
+            expect.objectContaining({
+              body: expectedRequest,
+            }),
+            expect.anything());
       });
 
       it('should throw on wrong type', () => {
-        expect(() => new CloudClient(testSession).tokStart('videoa', 'key', testTokSession)).toThrowError();
+        expect(() => new CloudClient(testSession).tokStart('videoa', testApiKey, testTokSession)).toThrowError('Type must be');
       });
     });
 
     describe('tokStop', () => {
-      it('should make correct request to api (audio)', async () => {
-        const res = await new CloudClient(testSession).tokStop('audio', 'key', testTokSession, testTokArchiveId);
+      const expectedRequest = { apikey: testApiKey, session_id: testTokSession, archive_id: testTokArchiveId };
+      it('should make correct request to api audio', async () => {
+        const mockTokStop = jest.fn().mockImplementationOnce(() => 'stop');
+        states.filestackApi.post('/recording/audio/stop', mockTokStop);
+        const res = await new CloudClient(testSession).tokStop('audio', testApiKey, testTokSession, testTokArchiveId);
 
-        expect(mockTokStop).toHaveBeenCalledWith(
-          expect.any(String),
-          JSON.stringify({
-            apikey: 'key',
-            session_id: testTokSession,
-            archive_id: testTokArchiveId,
-          })
-        );
-        expect(res).toEqual('stop');
+        expect(mockTokStop)
+          .toHaveBeenCalledWith(
+            expect.objectContaining({
+              body: expectedRequest,
+            }),
+            expect.anything());
+        expect(res).toEqual({ body: 'stop' });
       });
 
-      it('should make correct request to api (video)', async () => {
-        const res = await new CloudClient(testSession).tokStop('video', 'key', testTokSession, testTokArchiveId);
+      it('should make correct request to api video', async () => {
+        const mockTokStop = jest.fn();
+        states.filestackApi.post('/recording/video/stop', mockTokStop);
+        await new CloudClient(testSession).tokStop('video', testApiKey, testTokSession, testTokArchiveId);
 
-        expect(mockTokStop).toHaveBeenCalledWith(
-          expect.any(String),
-          JSON.stringify({
-            apikey: 'key',
-            session_id: testTokSession,
-            archive_id: testTokArchiveId,
-          })
-        );
-        expect(res).toEqual('stop');
+        expect(mockTokStop)
+          .toHaveBeenCalledWith(
+            expect.objectContaining({
+              body: expectedRequest,
+            }),
+            expect.anything()
+          );
       });
 
       it('should throw on wrong type', () => {
-        expect(() => new CloudClient(testSession).tokStop('videoa', 'key', testTokSession, testTokArchiveId)).toThrowError();
+        expect(() => new CloudClient(testSession).tokStop('videoa', 'key', testTokSession, testTokArchiveId)).toThrowError('Type must be');
       });
     });
   });


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Request for comments on a new testing library that could replace `nock` in testing HTTP traffic.

* **What is the current behavior?** (You can also link to an open issue here)

Tests in `cloud.spec.browser.ts` define a nock scope for every endpoint separately.

* **What is the new behavior (if this is a feature change)?**

Unmock intercepts all traffic by default and relies on service specification (like [OpenAPI](https://swagger.io/docs/specification/about/)) to verify requests and serve back mock data.

* **Other information**:

Hi!
I'm one of the authors of [unmock.io](https://unmock.io), a new open-source API testing library that I'm building with some colleagues. We are looking for repos where we feel unmock could reduce lines of code and increase clarity, and we thought that yours might be a good candidate.

The idea of unmock is that you drop in your service contract like an OpenAPI, Swagger, or RAML specification, and unmock then intercepts traffic and serves back semantically correct mock data for the service hit with request. I could not find any specification for `cloud.filestackapi.com` so I created a mock spec from scratch for the testing purposes. If such a specification existed, one could drop all the nock scope mocks for different endpoints and rely on the spec to (1) verify outgoing requests are valid and (2) be served back data of correct type so the handling of responses can be tested.

It'd be great if you could check out the PR and give us your thoughts - we hope you like it!