### PR TITLE
Add String.prototype.includes to polyfill

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ Module (for bundling):
 * https://babeljs.io/docs/en/babel-polyfill
 
 Script (for script tag):
-* https://polyfill.io/v3/polyfill.min.js?features=Promise%2CSymbol%2CSymbol.iterator%2CArray.from%2CObject.assign%2CNumber.isFinite
+* https://polyfill.io/v3/polyfill.min.js?features=Promise%2CSymbol%2CSymbol.iterator%2CArray.from%2CObject.assign%2CNumber.isFinite%2CString.prototype.includes
 
 ## Development
 


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

The picker fails under IE11 with the current polyfill:

`object doesn't support method or property 'includes'`

* **What is the new behavior (if this is a feature change)?**

Adding String.prototype.includes seems to fix it.

* **Other information**:
