### PR TITLE
fix (dependencies): Remove unused ts-node dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [3.16.0](https://github.com/filestack/filestack-js/compare/v3.15.0...v3.16.0) (2020-07-09)
+
+
+### Features
+
+* **picker:** bump picker version to 1.16.0 ([f595695](https://github.com/filestack/filestack-js/commit/f5956958e4301e8831851402cac72ff62ff36869))
+
 ## [3.15.0](https://github.com/filestack/filestack-js/compare/v3.14.0...v3.15.0) (2020-05-14)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [3.15.0](https://github.com/filestack/filestack-js/compare/v3.14.0...v3.15.0) (2020-05-14)
+
+
+### Features
+
+* **picker:** Fix picker problems with cropFiles, erorrHandlers, add better mime detection ([9dbe806](https://github.com/filestack/filestack-js/commit/9dbe8061b0db524a14766b71c9d018ad62ad93a5))
+* **pickerOptions:** add support email to picker options ([09d40b0](https://github.com/filestack/filestack-js/commit/09d40b06e0e8524a5b4a770694616b3a38931f45))
+
+
+### Bug Fixes
+
+* **mimetype:** Update mimetype detection function ([#356](https://github.com/filestack/filestack-js/issues/356)) ([bf4146d](https://github.com/filestack/filestack-js/commit/bf4146d9a4d0cf605d34424f510ca00ddfe6b8d6))
+
 ## [3.14.0](https://github.com/filestack/filestack-js/compare/v3.13.2...v3.14.0) (2020-04-21)
 
 ### [3.13.2](https://github.com/filestack/filestack-js/compare/v3.13.1...v3.13.2) (2020-04-07)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "filestack-js",
-  "version": "3.15.0",
+  "version": "3.16.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "filestack-js",
-  "version": "3.14.0",
+  "version": "3.15.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2625,11 +2625,6 @@
       "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
       "dev": true
     },
-    "arg": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA=="
-    },
     "argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -3498,7 +3493,8 @@
     "buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+      "dev": true
     },
     "buffer-xor": {
       "version": "1.0.3",
@@ -5247,7 +5243,8 @@
     "diff": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A=="
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true
     },
     "diff-sequences": {
       "version": "24.9.0",
@@ -12292,11 +12289,6 @@
         "semver": "^5.6.0"
       }
     },
-    "make-error": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="
-    },
     "make-iterator": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/make-iterator/-/make-iterator-1.0.1.tgz",
@@ -16886,34 +16878,6 @@
       "integrity": "sha512-c3zayb8/kWWpycWYg87P71E1S1ZL6b6IJxfb5fvsUgsf0S2MVGaDhDXXjDMpdCpfWXqptc+4mXwmiy1ypXqRAA==",
       "dev": true
     },
-    "ts-node": {
-      "version": "8.10.1",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.10.1.tgz",
-      "integrity": "sha512-bdNz1L4ekHiJul6SHtZWs1ujEKERJnHs4HxN7rjTyyVOFf3HaJ6sLqe6aPG62XTzAB/63pKRh5jTSWL0D7bsvw==",
-      "requires": {
-        "arg": "^4.1.0",
-        "diff": "^4.0.1",
-        "make-error": "^1.1.1",
-        "source-map-support": "^0.5.17",
-        "yn": "3.1.1"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-        },
-        "source-map-support": {
-          "version": "0.5.19",
-          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
-          "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
-          "requires": {
-            "buffer-from": "^1.0.0",
-            "source-map": "^0.6.0"
-          }
-        }
-      }
-    },
     "tslib": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
@@ -18325,11 +18289,6 @@
       "requires": {
         "camelcase": "^3.0.0"
       }
-    },
-    "yn": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
-      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "filestack-js",
-  "version": "3.15.0",
+  "version": "3.16.0",
   "description": "Official JavaScript library for Filestack",
   "main": "build/main/index.js",
   "module": "build/module/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "filestack-js",
-  "version": "3.14.0",
+  "version": "3.15.0",
   "description": "Official JavaScript library for Filestack",
   "main": "build/main/index.js",
   "module": "build/module/index.js",

--- a/package.json
+++ b/package.json
@@ -53,8 +53,7 @@
     "jsonschema": "^1.2.5",
     "lodash.clonedeep": "^4.5.0",
     "p-queue": "^4.0.0",
-    "spark-md5": "^3.0.0",
-    "ts-node": "^8.10.1"
+    "spark-md5": "^3.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.8.4",


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


* **What is the current behavior?** (You can also link to an open issue here)
`ts-node` is causing issues with `pnpm i --production` on `pnpm@5.x` where `typescript` cannot be found because it is in `devDependencies` in the consuming package.


* **What is the new behavior (if this is a feature change)?**
Remove unused `ts-node` in dependencies that was added by #356.


* **Other information**:
