### PR TITLE
fix(sentry): remove discouraged configureScope

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,8 @@ Error contains details field with responseBody, responseHeaders, code (only when
 ```
 
 ## Sentry Integration
-filestack-js now using [@sentry/minimal](https://www.npmjs.com/package/@sentry/minimal) package.
+
+If you're using [Sentry](https://sentry.io/welcome/) to monitor your application, Filestack will automatically report upload errors to Sentry, and tag them with helpful diagnostic information via [`@sentry/minimal`](https://github.com/getsentry/sentry-javascript/tree/master/packages/minimal).
 
 ## Versioning
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1765,36 +1765,36 @@
       }
     },
     "@sentry/hub": {
-      "version": "5.12.0",
-      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-5.12.0.tgz",
-      "integrity": "sha512-3k7yE8BEVJsKx8mR4LcI4IN0O8pngmq44OcJ/fRUUBAPqsT38jsJdP2CaWhdlM1jiNUzUDB1ktBv6/lY+VgcoQ==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.1.0.tgz",
+      "integrity": "sha512-JnBSCgNg3VHiMojUl5tCHU8iWPVuE+qqENIzG9A722oJms1kKWBvWl+yQzhWBNdgk5qeAY3F5UzKWJZkbJ6xow==",
       "requires": {
-        "@sentry/types": "5.12.0",
-        "@sentry/utils": "5.12.0",
+        "@sentry/types": "6.1.0",
+        "@sentry/utils": "6.1.0",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/minimal": {
-      "version": "5.12.0",
-      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-5.12.0.tgz",
-      "integrity": "sha512-fk73meyz4k4jCg9yzbma+WkggsfEIQWI2e2TWfYsRGcrV3RnlSrXyM4D91/A8Bjx10SNezHPUFHjasjlHXOkyA==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.1.0.tgz",
+      "integrity": "sha512-g6sfNKenL7wnsr/tibp8nFiMv/XRH0s0Pt4p151npmNI+SmjuUz3GGYEXk8ChCyaKldYKilkNOFdVXJxUf5gZw==",
       "requires": {
-        "@sentry/hub": "5.12.0",
-        "@sentry/types": "5.12.0",
+        "@sentry/hub": "6.1.0",
+        "@sentry/types": "6.1.0",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/types": {
-      "version": "5.12.0",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-5.12.0.tgz",
-      "integrity": "sha512-aZbBouBLrKB8wXlztriIagZNmsB+wegk1Jkl6eprqRW/w24Sl/47tiwH8c5S4jYTxdAiJk+SAR10AAuYmIN3zg=="
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.1.0.tgz",
+      "integrity": "sha512-kIaN52Fw5K+2mKRaHE2YluJ+F/qMGSUzZXIFDNdC6OUMXQ4TM8gZTrITXs8CLDm7cK8iCqFCtzKOjKK6KyOKAg=="
     },
     "@sentry/utils": {
-      "version": "5.12.0",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-5.12.0.tgz",
-      "integrity": "sha512-fYUadGLbfTCbs4OG5hKCOtv2jrNE4/8LHNABy9DwNJ/t5DVtGqWAZBnxsC+FG6a3nVqCpxjFI9AHlYsJ2wsf7Q==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.1.0.tgz",
+      "integrity": "sha512-6JAplzUOS6bEwfX0PDRZBbYRvn9EN22kZfcL0qGHtM9L0QQ5ybjbbVwOpbXgRkiZx++dQbzLFtelxnDhsbFG+Q==",
       "requires": {
-        "@sentry/types": "5.12.0",
+        "@sentry/types": "6.1.0",
         "tslib": "^1.9.3"
       }
     },
@@ -7490,7 +7490,8 @@
         },
         "ini": {
           "version": "1.3.5",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+          "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
           "dev": true,
           "optional": true
         },

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "dependencies": {
     "@babel/runtime": "^7.8.4",
     "@filestack/loader": "^1.0.4",
-    "@sentry/minimal": "^5.12.0",
+    "@sentry/minimal": "^6.1.0",
     "abab": "^2.0.3",
     "debug": "^4.1.1",
     "eventemitter3": "^4.0.0",

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -303,7 +303,7 @@ export class Client extends EventEmitter {
    * @param uploadTags Optional tags visible in webhooks.
    * @param headers    Optional headers to send
    */
-  storeURL(url: string, storeParams?: StoreParams, token?: any, security?: Security, uploadTags?: UploadTags, headers?: {[key: string]: string}): Promise<Object> {
+  storeURL(url: string, storeParams?: StoreParams, token?: any, security?: Security, uploadTags?: UploadTags, headers?: { [key: string]: string }): Promise<Object> {
     return storeURL({
       session: this.session,
       url,
@@ -432,9 +432,9 @@ export class Client extends EventEmitter {
     upload.on('error', e => {
       if (this.forwardErrors) {
         Sentry.withScope(scope => {
-          scope.setTag('apikey', this.session.apikey);
-          scope.setTag('sdk-version', Utils.getVersion());
-          scope.setExtra('clientOptions', this.options);
+          scope.setTag('filestack-apikey', this.session.apikey);
+          scope.setTag('filestack-version', Utils.getVersion());
+          scope.setExtra('filestack-options', this.options);
           scope.setExtras({ uploadOptions: options, storeOptions, details: e.details });
           e.message = `FS-${e.message}`;
 
@@ -496,9 +496,9 @@ export class Client extends EventEmitter {
     /* istanbul ignore next */
     upload.on('error', e => {
       Sentry.withScope(scope => {
-        scope.setTag('apikey', this.session.apikey);
-        scope.setTag('sdk-version', Utils.getVersion());
-        scope.setExtra('clientOptions', this.options);
+        scope.setTag('filestack-apikey', this.session.apikey);
+        scope.setTag('filestack-version', Utils.getVersion());
+        scope.setExtra('filestack-options', this.options);
         scope.setExtras(e.details);
         scope.setExtras({ uploadOptions: options, storeOptions });
         Sentry.captureException(e);

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -110,20 +110,13 @@ export class Client extends EventEmitter {
     return Utils;
   }
 
-  constructor(apikey: string, options?: ClientOptions) {
+  constructor(apikey: string, private options?: ClientOptions) {
     super();
 
     /* istanbul ignore if */
     if (options && options.forwardErrors) {
       this.forwardErrors = options.forwardErrors;
     }
-
-    /* istanbul ignore next */
-    Sentry.configureScope(scope => {
-      scope.setTag('apikey', apikey);
-      scope.setTag('sdk-version', Utils.getVersion());
-      scope.setExtra('clientOptions', options);
-    });
 
     if (!apikey || typeof apikey !== 'string' || apikey.length === 0) {
       throw new Error('An apikey is required to initialize the Filestack client');
@@ -439,6 +432,9 @@ export class Client extends EventEmitter {
     upload.on('error', e => {
       if (this.forwardErrors) {
         Sentry.withScope(scope => {
+          scope.setTag('apikey', this.session.apikey);
+          scope.setTag('sdk-version', Utils.getVersion());
+          scope.setExtra('clientOptions', this.options);
           scope.setExtras({ uploadOptions: options, storeOptions, details: e.details });
           e.message = `FS-${e.message}`;
 
@@ -500,6 +496,9 @@ export class Client extends EventEmitter {
     /* istanbul ignore next */
     upload.on('error', e => {
       Sentry.withScope(scope => {
+        scope.setTag('apikey', this.session.apikey);
+        scope.setTag('sdk-version', Utils.getVersion());
+        scope.setExtra('clientOptions', this.options);
         scope.setExtras(e.details);
         scope.setExtras({ uploadOptions: options, storeOptions });
         Sentry.captureException(e);


### PR DESCRIPTION
* **What kind of change does this PR introduce?**

    Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

    See https://github.com/filestack/filestack-js/issues/416

* **What is the new behavior (if this is a feature change)?**

    `Sentry.configureScope` is no longer invoked in hopes this fixes Sentry application context issues
