### PR TITLE
[Fix] (sentry-416): use Sentry v6 version

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "dependencies": {
     "@babel/runtime": "^7.8.4",
     "@filestack/loader": "^1.0.4",
-    "@sentry/minimal": "^5.12.0",
+    "@sentry/minimal": "^6.1.0",
     "abab": "^2.0.3",
     "debug": "^4.1.1",
     "eventemitter3": "^4.0.0",


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


* **What is the current behavior?** (You can also link to an open issue here)
See #416 


* **What is the new behavior (if this is a feature change)?**
Use Sentry's v6.1.0 (from v6, the `hub.startSession` is used)

