### PR TITLE
fix(extensions): Changed avi format for assertion purpose

### DIFF
--- a/src/lib/utils/extensions.ts
+++ b/src/lib/utils/extensions.ts
@@ -920,7 +920,7 @@ export const ExtensionsMap = {
   'video/x-ms-wmv': ['wmv'],
   'video/x-ms-wmx': ['wmx'],
   'video/x-ms-wvx': ['wvx'],
-  'video/x-msvideo': ['avi'],
+  'video/vnd.avi': ['avi'],
   'video/x-sgi-movie': ['movie'],
   'video/x-smv': ['smv'],
   'x-conference/x-cooltalk': ['ice'],


### PR DESCRIPTION
**Bugfix**

Currently `.avi` files were not properly validated even when in `accept` array, .avi extension has been placed. This change is fixing this issue by modifying **ExtensionMap** const key for avi file extension. 

While using file-type library for checking mime type of files, there is a need to apply the same value of returned mime-type (https://github.com/sindresorhus/file-type/blob/v10.11.0/index.js#L345)

