### PR TITLE
Validation schema added for default image search

### DIFF
--- a/src/lib/picker.ts
+++ b/src/lib/picker.ts
@@ -415,6 +415,15 @@ export interface PickerOptions {
    */
   fromSources?: string[];
   /**
+   * Provide default text value for Image Search
+   * ```javascript
+   * websearch: {
+   *  predefinedText: 'Sample text'
+   * }
+   * ```
+   */
+  websearch?: object;
+  /**
    * Container where picker should be appended. Only relevant for `inline` and `dropPane` display modes.
    */
   container?: string | Node;

--- a/src/schema/picker.schema.ts
+++ b/src/schema/picker.schema.ts
@@ -47,6 +47,14 @@ export const PickerParamsSchema = {
     acceptFn: {
       format: 'callback',
     },
+    websearch: {
+      type: 'object',
+      properties: {
+        predefinedText: {
+          type: 'string'
+        }
+      },
+    },
     fromSources: {
       type: 'array',
       items: [


### PR DESCRIPTION
This change adds validation schema for new default text feature introduced for image search.

The following properties have been introduced for the same:
websearch: {
      predefinedText: 'Sample text'
  }
