### PR TITLE
Added parameter for audio_codec in VideoConvertParams

### DIFF
--- a/src/lib/api/transform.ts
+++ b/src/lib/api/transform.ts
@@ -144,6 +144,20 @@ export enum EImageWatermarkPosition {
 /**
  * Convert to format
  */
+export enum EAudioTypes {
+  libmp3lame = 'libmp3lame',
+  libvorbis = 'libvorbis',
+  libfdk_aac = 'libfdk_aac',
+  dib_ac3 = 'dib_ac3',
+  pcm_s16le = 'pcm_s16le',
+  mp2 = 'mp2',
+  ac3 = 'ac3',
+  eac3 = 'eac3',
+}
+
+/**
+ * Convert to format
+ */
 export enum EVideoTypes {
     h264 = 'h264',
     h264_hi = 'h264.hi',
@@ -408,6 +422,7 @@ export interface TransformOptions {
     access?: EVideoAccess;
     container?: string;
     audio_bitrate?: number;
+    audio_codec?: EAudioTypes;
     upscale: boolean;
     video_bitrate?: number;
     audio_sample_rate?: number;

--- a/src/lib/filelink.ts
+++ b/src/lib/filelink.ts
@@ -124,6 +124,20 @@ export enum SmartCropMode {
 /**
  * Convert to format
  */
+export enum AudioTypes {
+  libmp3lame = 'libmp3lame',
+  libvorbis = 'libvorbis',
+  libfdk_aac = 'libfdk_aac',
+  dib_ac3 = 'dib_ac3',
+  pcm_s16le = 'pcm_s16le',
+  mp2 = 'mp2',
+  ac3 = 'ac3',
+  eac3 = 'eac3',
+}
+
+/**
+ * Convert to format
+ */
 export enum VideoTypes {
   h264 = 'h264',
   h264_hi = 'h264.hi',
@@ -430,6 +444,7 @@ export interface VideoConvertParams {
   access?: VideoAccess;
   container?: string;
   audio_bitrate?: number;
+  audio_codec?: AudioTypes;
   upscale: boolean;
   video_bitrate?: number;
   audio_sample_rate?: number;

--- a/src/schema/transforms.schema.ts
+++ b/src/schema/transforms.schema.ts
@@ -1046,6 +1046,9 @@ export const TransformSchema = {
           minimum: 1,
           maximum: 999,
         },
+        audio_codec: {
+          type: 'string',
+        },
         audio_channels: {
           type: 'integer',
           minimum: 1,


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
It adds audio_codec parameter to video_convert in TransformOptions


* **What is the current behavior?**
video_convert in TransformOptions does not have audio_codec parameter 
https://filestack.atlassian.net/browse/FS-10439


* **What is the new behavior (if this is a feature change)?**
video_convert in TransformOptions can receive audio_codec parameter with any of the values listed here
https://www.filestack.com/docs/api/video_processing/#audio-transcoding-options

Manual test:
https://drive.google.com/file/d/1yk5EF5zMBWF4FuVHRPLpHsLEdGCcMbr2/view?usp=sharing
Rebased to the branch with latest packages and ran tests:
![image](https://user-images.githubusercontent.com/6235703/225859670-b7785588-1a31-40ef-9035-a8c7d20bbaf6.png)

