### PR TITLE
Bump fast-xml-parser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6771,9 +6771,12 @@
       "dev": true
     },
     "fast-xml-parser": {
-      "version": "3.16.0",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.16.0.tgz",
-      "integrity": "sha512-U+bpScacfgnfNfIKlWHDu4u6rtOaCyxhblOLJ8sZPkhsjgGqdZmVPBhdOyvdMGCDt8CsAv+cssOP3NzQptNt2w=="
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.4.tgz",
+      "integrity": "sha512-fbfMDvgBNIdDJLdLOwacjFAPYt67tr31H9ZhWSm45CDAxvd0I6WTlSOUo7K2P/K5sA5JgMKG64PI3DMcaFdWpQ==",
+      "requires": {
+        "strnum": "^1.0.5"
+      }
     },
     "fastq": {
       "version": "1.6.0",
@@ -17005,6 +17008,11 @@
       "resolved": "https://registry.npmjs.org/strip-url-auth/-/strip-url-auth-1.0.1.tgz",
       "integrity": "sha1-IrD6OkE4WzO+PzMVUbu4N/oM164=",
       "dev": true
+    },
+    "strnum": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
+      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
     },
     "stubs": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "abab": "^2.0.3",
     "debug": "^4.1.1",
     "eventemitter3": "^4.0.0",
-    "fast-xml-parser": "^3.16.0",
+    "fast-xml-parser": "^4.2.4",
     "file-type": "^10.11.0",
     "follow-redirects": "^1.10.0",
     "isutf8": "^2.1.0",

--- a/src/lib/request/helpers/data.ts
+++ b/src/lib/request/helpers/data.ts
@@ -18,7 +18,7 @@ import { isURLSearchParams, isObject, isStream, isFormData, isArrayBuffer, isFil
 import { getVersion, uniqueId } from './../../utils';
 import { FsRequestOptions, FsResponse } from './../types';
 import { set } from './headers';
-import * as parser from 'fast-xml-parser';
+import { XMLParser, XMLValidator } from 'fast-xml-parser';
 import Debug from 'debug';
 
 const debug = Debug('fs:request:data');
@@ -99,11 +99,14 @@ export const parseResponse = async (response: FsResponse): Promise<FsResponse> =
       data = bufferToString(response.data);
     }
 
-    if (parser.validate(data) === true) {
-      response.data = parser.parse(data, {
+    if (XMLValidator.validate(data) === true) {
+      const parser = new XMLParser({
+        ignoreDeclaration: true,
         ignoreAttributes : true,
         trimValues: true,
       });
+
+      response.data = parser.parse(data);
     }
   }
 


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

It's a security upgrade based on https://github.com/filestack/filestack-js/pull/518 . Dependabot did the version bump and then I fixed the tests.

* **What is the current behavior?** (You can also link to an open issue here)

Currently there are a few CVEs asking for an upgrade of the fast-xml-parser package.

* **What is the new behavior (if this is a feature change)?**

Based on the tests, it works as before, but without the security warnings.

* **Other information**:

  * https://github.com/advisories/GHSA-6w63-h3fj-q4vw
  * https://github.com/advisories/GHSA-x3cc-x39p-42qx
