### PR TITLE
Update store.browser.ts to handle window.localStorage access error

### DIFF
--- a/src/lib/utils/store.browser.ts
+++ b/src/lib/utils/store.browser.ts
@@ -24,7 +24,13 @@ export class Store {
   private availableTypes = [];
 
   constructor() {
-    if (window.localStorage !== undefined) {
+    let localStorage: Storage | undefined = undefined;
+    try {
+      localStorage = window.localStorage;
+    } catch {
+      debug('Local storage access denied');
+    }
+    if (localStorage !== undefined) {
       this.availableTypes.push(STORE_TYPE.LOCAL);
       debug('Local storage exists');
     }


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

🐛 Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

`window.localStorage` crashes in an iframe with an `Access Denied` error. The code is already resilient to `localStorage` not existing, it's just not resilient to `localStorage` throwing an error. This PR includes a minor code structure change so that it handles this case.

* **What is the new behavior (if this is a feature change)?**

Does not crash in iframes, properly falls back to other storage

* **Other information**:
