### PR TITLE
Redundant test cases removed as per new chunk size calculation

### DIFF
--- a/src/lib/api/upload/uploaders/s3.spec.ts
+++ b/src/lib/api/upload/uploaders/s3.spec.ts
@@ -723,37 +723,6 @@ describe('Api/Upload/Uploaders/S3', () => {
           part: 1,
         });
 
-        const chunk2 = await testFile.getChunkByMetadata(firstPartMetadata, chunkSize / 2, chunkSize);
-
-        expect(mockUpload).toHaveBeenNthCalledWith(3, {
-          md5: chunk2.md5,
-          size: chunk2.size,
-          apikey: testApikey,
-          region: mockRegion,
-          store: {
-            location: DEFAULT_STORE_LOCATION,
-          },
-          fii: true,
-          uri: mockedUri,
-          upload_id: mockUploadId,
-          offset: chunkSize,
-          part: 1,
-        });
-      });
-
-      it('should exit when chunk size reaches min chunk size', async () => {
-        nock.removeInterceptor(interceptorS3);
-        scope.put('/fakes3').reply((url, _, cb) => cb('Error'));
-
-        const u = new S3Uploader({});
-        u.setUrl(testHost);
-        u.setApikey(testApikey);
-        u.setTimeout(100);
-        u.setUploadMode(UploadMode.INTELLIGENT);
-
-        u.addFile(getSmallTestFile());
-        const res = await u.execute();
-        expect(res[0].status).toEqual('Failed');
       });
 
       it('should exit on 4xx errors', async () => {


### PR DESCRIPTION
What kind of change does this PR introduce?

- Redundant unit test cases removed.

What is the current behavior?

- Chunk size was static so, parts calculation was done according to the static values

What is the new behavior (if this is a feature change)?

- Chunk size is dynamic , so parts calculation will differ here.

The above change was added in this commit earlier,
https://github.com/filestack/filestack-js/pull/516/files
