### PR TITLE
fix: [FS-11598] Added fallback type as application/octet-stream

### DIFF
--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -103,11 +103,13 @@ export const uniqueId = (len: number = 10): string => {
  */
 export const getMimetype = async(file: Uint8Array | Buffer, name?: string): Promise<string> => {
   let type;
+
   try {
      type = await fromBuffer(file);
   } catch(e) {
     console.warn("An exception occurred while processing the buffer:", e.message);
   }
+
   if (name && name.indexOf('.') > -1) {
     const mime = extensionToMime(name);
 
@@ -115,6 +117,7 @@ export const getMimetype = async(file: Uint8Array | Buffer, name?: string): Prom
       return mime;
     }
   }
+
   const excludedMimetypes = ['text/plain', 'application/octet-stream', 'application/x-ms', 'application/x-msi', 'application/zip'];
 
   if (type && excludedMimetypes.indexOf(type.mime) === -1) {
@@ -137,6 +140,7 @@ export const getMimetype = async(file: Uint8Array | Buffer, name?: string): Prom
     return type.mime;
   }
 
+  return 'application/octet-stream';
 };
 
 /**


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix -  Added fallback type as application/octet-stream


* **What is the current behavior?** (You can also link to an open issue here)
No fallback for file type


* **What is the new behavior (if this is a feature change)?**
 Added fallback type as application/octet-stream


* **Other information**:
