### PR TITLE
Update Sentry version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,12 +6,12 @@
   "packages": {
     "": {
       "name": "filestack-js",
-      "version": "3.29.0",
+      "version": "3.32.1",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.8.4",
         "@filestack/loader": "^1.0.9",
-        "@sentry/minimal": "^6.19.7",
+        "@sentry/core": "^8.9.1",
         "abab": "^2.0.6",
         "debug": "^4.3.4",
         "eventemitter3": "^5.0.0",
@@ -3217,66 +3217,36 @@
         "webpack": ">= 4.0.0"
       }
     },
-    "node_modules/@sentry/hub": {
-      "version": "6.19.7",
-      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.19.7.tgz",
-      "integrity": "sha512-y3OtbYFAqKHCWezF0EGGr5lcyI2KbaXW2Ik7Xp8Mu9TxbSTuwTe4rTntwg8ngPjUQU3SUHzgjqVB8qjiGqFXCA==",
+    "node_modules/@sentry/core": {
+      "version": "8.9.1",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-8.9.1.tgz",
+      "integrity": "sha512-7Q1yB4ZMJoNT6LsBVx1EyTsVemqYuKZoyEDEzZOYZsa/W438oF7M6g0JqK6TJG8JIZN50Lj5MrJOs6FAu51CCw==",
       "dependencies": {
-        "@sentry/types": "6.19.7",
-        "@sentry/utils": "6.19.7",
-        "tslib": "^1.9.3"
+        "@sentry/types": "8.9.1",
+        "@sentry/utils": "8.9.1"
       },
       "engines": {
-        "node": ">=6"
+        "node": ">=14.18"
       }
     },
-    "node_modules/@sentry/hub/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    "node_modules/@sentry/core/node_modules/@sentry/types": {
+      "version": "8.9.1",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-8.9.1.tgz",
+      "integrity": "sha512-V+TkaDVhakH/oW6f1KQiRbvHcczQLEzdwlH2lAP5Flh+wESS5VaSPqj+esLg53GFF8q0tw7QH1tSUGXWeGoJ5g==",
+      "engines": {
+        "node": ">=14.18"
+      }
     },
-    "node_modules/@sentry/minimal": {
-      "version": "6.19.7",
-      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.19.7.tgz",
-      "integrity": "sha512-wcYmSJOdvk6VAPx8IcmZgN08XTXRwRtB1aOLZm+MVHjIZIhHoBGZJYTVQS/BWjldsamj2cX3YGbGXNunaCfYJQ==",
+    "node_modules/@sentry/core/node_modules/@sentry/utils": {
+      "version": "8.9.1",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-8.9.1.tgz",
+      "integrity": "sha512-9TROyW7PbyokwVO41wIhQRenhW+kPg2ws2nzz21aFbLCrwXvF2nNsZ67roeXOiu9n2Oy/O1yEksPOcT4zFcesQ==",
       "dependencies": {
-        "@sentry/hub": "6.19.7",
-        "@sentry/types": "6.19.7",
-        "tslib": "^1.9.3"
+        "@sentry/types": "8.9.1"
       },
       "engines": {
-        "node": ">=6"
+        "node": ">=14.18"
       }
-    },
-    "node_modules/@sentry/minimal/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-    },
-    "node_modules/@sentry/types": {
-      "version": "6.19.7",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.19.7.tgz",
-      "integrity": "sha512-jH84pDYE+hHIbVnab3Hr+ZXr1v8QABfhx39KknxqKWr2l0oEItzepV0URvbEhB446lk/S/59230dlUUIBGsXbg==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@sentry/utils": {
-      "version": "6.19.7",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.19.7.tgz",
-      "integrity": "sha512-z95ECmE3i9pbWoXQrD/7PgkBAzJYR+iXtPuTkpBjDKs86O3mT+PXOT3BAn79w2wkn7/i3vOGD2xVr1uiMl26dA==",
-      "dependencies": {
-        "@sentry/types": "6.19.7",
-        "tslib": "^1.9.3"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@sentry/utils/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
@@ -27268,58 +27238,27 @@
         "webpack-sources": "^1.0.0"
       }
     },
-    "@sentry/hub": {
-      "version": "6.19.7",
-      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.19.7.tgz",
-      "integrity": "sha512-y3OtbYFAqKHCWezF0EGGr5lcyI2KbaXW2Ik7Xp8Mu9TxbSTuwTe4rTntwg8ngPjUQU3SUHzgjqVB8qjiGqFXCA==",
+    "@sentry/core": {
+      "version": "8.9.1",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-8.9.1.tgz",
+      "integrity": "sha512-7Q1yB4ZMJoNT6LsBVx1EyTsVemqYuKZoyEDEzZOYZsa/W438oF7M6g0JqK6TJG8JIZN50Lj5MrJOs6FAu51CCw==",
       "requires": {
-        "@sentry/types": "6.19.7",
-        "@sentry/utils": "6.19.7",
-        "tslib": "^1.9.3"
+        "@sentry/types": "8.9.1",
+        "@sentry/utils": "8.9.1"
       },
       "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
-      }
-    },
-    "@sentry/minimal": {
-      "version": "6.19.7",
-      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.19.7.tgz",
-      "integrity": "sha512-wcYmSJOdvk6VAPx8IcmZgN08XTXRwRtB1aOLZm+MVHjIZIhHoBGZJYTVQS/BWjldsamj2cX3YGbGXNunaCfYJQ==",
-      "requires": {
-        "@sentry/hub": "6.19.7",
-        "@sentry/types": "6.19.7",
-        "tslib": "^1.9.3"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
-      }
-    },
-    "@sentry/types": {
-      "version": "6.19.7",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.19.7.tgz",
-      "integrity": "sha512-jH84pDYE+hHIbVnab3Hr+ZXr1v8QABfhx39KknxqKWr2l0oEItzepV0URvbEhB446lk/S/59230dlUUIBGsXbg=="
-    },
-    "@sentry/utils": {
-      "version": "6.19.7",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.19.7.tgz",
-      "integrity": "sha512-z95ECmE3i9pbWoXQrD/7PgkBAzJYR+iXtPuTkpBjDKs86O3mT+PXOT3BAn79w2wkn7/i3vOGD2xVr1uiMl26dA==",
-      "requires": {
-        "@sentry/types": "6.19.7",
-        "tslib": "^1.9.3"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        "@sentry/types": {
+          "version": "8.9.1",
+          "resolved": "https://registry.npmjs.org/@sentry/types/-/types-8.9.1.tgz",
+          "integrity": "sha512-V+TkaDVhakH/oW6f1KQiRbvHcczQLEzdwlH2lAP5Flh+wESS5VaSPqj+esLg53GFF8q0tw7QH1tSUGXWeGoJ5g=="
+        },
+        "@sentry/utils": {
+          "version": "8.9.1",
+          "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-8.9.1.tgz",
+          "integrity": "sha512-9TROyW7PbyokwVO41wIhQRenhW+kPg2ws2nzz21aFbLCrwXvF2nNsZ67roeXOiu9n2Oy/O1yEksPOcT4zFcesQ==",
+          "requires": {
+            "@sentry/types": "8.9.1"
+          }
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "dependencies": {
     "@babel/runtime": "^7.8.4",
     "@filestack/loader": "^1.0.9",
-    "@sentry/minimal": "^6.19.7",
+    "@sentry/core": "^8.9.1",
     "abab": "^2.0.6",
     "debug": "^4.3.4",
     "eventemitter3": "^5.0.0",

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -16,7 +16,7 @@
  */
 
 import { EventEmitter } from 'eventemitter3';
-import * as Sentry from '@sentry/minimal';
+import * as Sentry from '@sentry/core';
 import { config, Hosts } from '../config';
 import { FilestackError } from './../filestack_error';
 import { metadata, MetadataOptions, remove, retrieve, RetrieveOptions, download } from './api/file';
@@ -305,7 +305,15 @@ export class Client extends EventEmitter {
    * @param headers    Optional headers to send
    * @param workflowIds    Optional workflowIds to send
    */
-  storeURL(url: string, storeParams?: StoreParams, token?: any, security?: Security, uploadTags?: UploadTags, headers?: {[key: string]: string}, workflowIds?: string[]): Promise<Object> {
+  storeURL(
+    url: string,
+    storeParams?: StoreParams,
+    token?: any,
+    security?: Security,
+    uploadTags?: UploadTags,
+    headers?: { [key: string]: string },
+    workflowIds?: string[]
+  ): Promise<Object> {
     return storeURL({
       session: this.session,
       url,


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Update Sentry dependency (fixes issues related to the conflict of the Sentry SDK v8+)



* **What is the current behavior?** (You can also link to an open issue here)
In the Sentry v7-v8 the **@sentry/hub** was merged with **@sentry/core** and than the `__SENTRY__.hub` was [completely](https://github.com/getsentry/sentry-javascript/issues/5665) [removed](https://github.com/getsentry/sentry-javascript/commit/465bd2954a48838e37efa2c34bd12aea2925bb2d). The **@sentry/minimal** has not been updated for a long time and uses `__SENTRY__.hub.isOlderThan()` method failing with the error of missing variable.


* **What is the new behavior (if this is a feature change)?**
Instead of **@sentry/minimal** it uses **@sentry/core** that is aware of new SDK version and uses it without throwing exceptions.


* **Other information**:
—