### PR TITLE
Ensure options parameter of upload() is optional

### DIFF
--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -475,7 +475,7 @@ export class Client extends EventEmitter {
       this.emit('upload.error', e);
     });
 
-    return upload.upload(file, options.altText);
+    return upload.upload(file, options?.altText);
   }
 
   /**


### PR DESCRIPTION
Hey :wave: 

* **What kind of change does this PR introduce?**
Bug fix

* **What is the current behavior?**
Since 3.33.3 (as far as I've tested, but the screenshot was captured used 3.34.3), the options parameter of the `client.upload()` method is marked as optional, but will error out if the param is undefined when it hits `options.altText`:

![Screenshot from 2024-10-02 12-00-32](https://github.com/user-attachments/assets/4edea1d6-6a2e-4959-9ab6-d1fadcc3339b)

As a workaround, we're passing an empty object as the second argument.

* **What is the new behavior (if this is a feature change)?**
The optional `options` parameter can be undefined.