### PR TITLE
FS-11939 - Add separate hash encoding for filename and mimetype to address the vulnerability

### DIFF
--- a/src/lib/api/upload/uploaders/s3.spec.ts
+++ b/src/lib/api/upload/uploaders/s3.spec.ts
@@ -65,6 +65,7 @@ const testHost = 'https://filestack-test.com';
 const mockUploadId = '123132123';
 const mockRegion = 'test-region';
 const mockedUri = '/sometest';
+const mockFileHash= 'test'
 const s3Url = testHost + '/fakes3';
 
 const mockStart = jest.fn().mockName('multipart/start');
@@ -100,6 +101,7 @@ describe('Api/Upload/Uploaders/S3', () => {
       region: mockRegion,
       upload_id: mockUploadId,
       location_url: testHost,
+      filehash: mockFileHash,
     });
 
     mockUpload.mockReturnValue({
@@ -121,6 +123,7 @@ describe('Api/Upload/Uploaders/S3', () => {
       mimetype: 'test_mimetype',
       status: 'test_status',
       upload_tags: { test: 123 },
+      filehash: mockFileHash,
     });
   });
 
@@ -224,6 +227,7 @@ describe('Api/Upload/Uploaders/S3', () => {
         region: mockRegion,
         upload_id: mockUploadId,
         location_url: testHost.replace('https://', ''),
+        filehash: mockFileHash,
       });
 
       const u = new S3Uploader({});
@@ -245,6 +249,7 @@ describe('Api/Upload/Uploaders/S3', () => {
         region: mockRegion,
         upload_id: mockUploadId,
         location_url: testHost.replace('https://', ''),
+        filehash: mockFileHash,
       });
 
       const u = new S3Uploader({});
@@ -264,6 +269,7 @@ describe('Api/Upload/Uploaders/S3', () => {
         region: mockRegion,
         upload_id: mockUploadId,
         location_url: testHost.replace('https://', ''),
+        filehash: mockFileHash,
       });
 
       interceptorS3.once().reply(200, s3Callback, {});
@@ -288,6 +294,7 @@ describe('Api/Upload/Uploaders/S3', () => {
         upload_id: mockUploadId,
         location_region: 'test',
         location_url: testHost.replace('https://', ''),
+        filehash: mockFileHash,
       });
 
       interceptorUpload.reply(200, function(_, data) {
@@ -495,6 +502,7 @@ describe('Api/Upload/Uploaders/S3', () => {
           upload_id: mockUploadId,
           location_url: testHost,
           upload_type: 'intelligent_ingestion',
+          filehash: mockFileHash,
         });
       });
 
@@ -571,6 +579,7 @@ describe('Api/Upload/Uploaders/S3', () => {
           },
           fii: true,
           uri: mockedUri,
+          filehash: mockFileHash,
         });
       });
 
@@ -647,6 +656,7 @@ describe('Api/Upload/Uploaders/S3', () => {
           },
           fii: true,
           uri: mockedUri,
+          filehash: mockFileHash,
         });
       });
 
@@ -732,6 +742,7 @@ describe('Api/Upload/Uploaders/S3', () => {
           upload_id: mockUploadId,
           location_url: testHost,
           upload_type: 'intelligent_ingestion',
+          filehash: mockFileHash,
         });
 
         interceptorS3.reply(400, {
@@ -781,6 +792,7 @@ describe('Api/Upload/Uploaders/S3', () => {
           upload_id: mockUploadId,
           location_url: testHost,
           upload_type: 'intelligent_ingestion',
+          filehash: mockFileHash,
         });
 
         let networkFail = true;
@@ -847,6 +859,7 @@ describe('Api/Upload/Uploaders/S3', () => {
           region: mockRegion,
           upload_id: mockUploadId,
           location_url: testHost,
+          filehash: mockFileHash,
         });
 
         let networkFail = true;
@@ -948,6 +961,7 @@ describe('Api/Upload/Uploaders/S3', () => {
           location: DEFAULT_STORE_LOCATION,
         },
         uri: mockedUri,
+        filehash: mockFileHash,
       });
 
       expect(res[0].handle).toEqual('test_handle');
@@ -1021,6 +1035,7 @@ describe('Api/Upload/Uploaders/S3', () => {
           location: DEFAULT_STORE_LOCATION,
         },
         uri: mockedUri,
+        filehash: mockFileHash,
       });
 
       expect(res[0].handle).toEqual('test_handle');

--- a/src/lib/api/upload/uploaders/s3.ts
+++ b/src/lib/api/upload/uploaders/s3.ts
@@ -44,6 +44,7 @@ export interface UploadPayload {
   upload_id?: number;
   location_url?: string;
   location_region?: string;
+  filehash?: string;
 }
 
 export class S3Uploader extends UploaderAbstract {
@@ -213,6 +214,7 @@ export class S3Uploader extends UploaderAbstract {
       upload_id: payload.upload_id,
       region: payload.region,
       alt: payload.file.alt,
+      filehash: payload.filehash,
     };
 
     if (this.uploadMode === UploadMode.INTELLIGENT || (this.uploadMode === UploadMode.FALLBACK && fiiFallback)) {
@@ -312,7 +314,7 @@ export class S3Uploader extends UploaderAbstract {
       }
     )
       .then(({ data }) => {
-        if (!data || !data.location_url || !data.region || !data.upload_id || !data.uri) {
+        if (!data || !data.location_url || !data.region || !data.upload_id || !data.uri || !data.filehash) {
           debug(`[${id}] Incorrect start response: \n%O\n`, data);
           this.setPayloadStatus(id, FileState.FAILED);
           return Promise.reject(new FilestackError('Incorrect start response', data, FilestackErrorType.REQUEST));
@@ -688,7 +690,7 @@ export class S3Uploader extends UploaderAbstract {
     return FsRequest.post(
       `${this.getUploadUrl(id)}/multipart/complete`,
       {
-        ...this.getDefaultFields(id, ['apikey', 'policy', 'signature', 'uri', 'region', 'upload_id', 'fii', 'alt'], true),
+        ...this.getDefaultFields(id, ['apikey', 'policy', 'signature', 'uri', 'region', 'upload_id', 'fii', 'alt', 'filehash'], true),
         // method specific keys
         filename: payload.file.name,
         mimetype: payload.file.type,


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Send the encoded filehash key in **/complete** API payload request which recieved from **/start** API response to check the mimetype and filename vulnerability issue.


* **What is the current behavior?** (You can also link to an open issue here)
filehash key not send in /complete payload request.


* **What is the new behavior (if this is a feature change)?**
filehash sends in /complete payload request.


* **Other information**:
   Fixed test cases related to new changes.
