### PR TITLE
FS-12788 Stop Chunk Splitting to Prevent Dynamic Import Error

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,6 +9,10 @@ const banner = fs.readFileSync('./LICENSE', 'utf8').replace('{year}', new Date()
 
 const baseConfig = {
   mode: 'production',
+  optimization: {
+    splitChunks: false,
+    runtimeChunk: false,
+  },
   watchOptions: {
     ignored: /node_modules/
   },
@@ -39,6 +43,7 @@ const baseConfig = {
     maxAssetSize: 255000
   },
   plugins: [
+    new webpack.optimize.LimitChunkCountPlugin({ maxChunks: 1 }),
     {
       apply: (compiler) => {
         compiler.hooks.beforeRun.tap('SourceMapInit', () => {


### PR DESCRIPTION
Hi,

This PR is the part of the fix of ticket - **FS-12788**

`file-type` was upgraded from v16 to v22, which moved from CommonJS to pure ESM. This caused webpack to split the output into multiple async chunks instead of a single bundle.

Angular's build tool (esbuild) wasn't expecting async chunks in the library output — while trying to resolve them, it stumbled upon the .map sourcemap files and threw an error since it has no loader configured for them.

The fix forces webpack to always produce a single self-contained bundle, regardless of any dynamic imports inside file-type v22.

Please review.

Thanks!
