### PR TITLE
FS-12472: virtual-form POST on /folder/list to set cross-domain

### DIFF
--- a/src/lib/api/cloud.ts
+++ b/src/lib/api/cloud.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { removeEmpty } from '../utils';
+import { removeEmpty, uniqueId } from '../utils';
 import { StoreParams } from '../filelink';
 import { ClientOptions, Session } from '../client';
 import { FilestackError } from './../../filestack_error';
@@ -127,6 +127,8 @@ export class CloudClient {
       clouds,
       flow: 'web',
       token: this.token,
+      // FS-12472: shared CSRF nonce so the virtual-form cookie matches the auth URL's state.
+      oauth_csrf_nonce: uniqueId(32),
     };
 
     if (accept) {
@@ -160,7 +162,8 @@ export class CloudClient {
       options.cancelToken = cancelToken;
     }
 
-    return FsRequest.post(`${this.cloudApiUrl}/folder/list`, payload, options).then(res => {
+    // FS-12472: virtual-form POST lets cloudrouter set the cross-domain cookie via native form behavior.
+    return FsRequest.postForm(`${this.cloudApiUrl}/folder/list`, payload, options).then(res => {
       if (res.data && res.data.token) {
         this.token = res.data.token;
       }

--- a/src/lib/request/adapters/xhr.ts
+++ b/src/lib/request/adapters/xhr.ts
@@ -23,6 +23,89 @@ import { prepareData, parseResponse, parse as parseHeaders, combineURL } from '.
 
 const debug = Debug('fs:request:xhr');
 const CANCEL_CLEAR = `FsCleanMemory`;
+let virtualFormId = 0;
+
+const isDomAvailable = (): boolean => typeof document !== 'undefined' && typeof window !== 'undefined' && typeof document.createElement === 'function' && !!document.body;
+
+const appendHiddenInput = (form: HTMLFormElement, name: string, value: any) => {
+  const input = document.createElement('input');
+  input.type = 'hidden';
+  input.name = name;
+  input.value = value === null || value === undefined ? '' : typeof value === 'object' ? JSON.stringify(value) : String(value);
+  form.appendChild(input);
+};
+
+const submitVirtualForm = (url: string, data: any, config: FsRequestOptions): Promise<void> => {
+  if (!isDomAvailable()) {
+    return Promise.reject(new FsRequestError('Virtual form requests are only supported in browser environments', config, null, FsRequestErrorCode.REQUEST));
+  }
+
+  const targetName = `fsVirtualFormTarget_${Date.now()}_${virtualFormId++}`;
+  const iframe = document.createElement('iframe');
+  iframe.name = targetName;
+  iframe.style.display = 'none';
+  iframe.setAttribute('aria-hidden', 'true');
+  iframe.src = 'about:blank';
+
+  const form = document.createElement('form');
+  form.method = 'POST';
+  form.action = url;
+  form.target = targetName;
+  form.enctype = 'multipart/form-data';
+  form.acceptCharset = 'UTF-8';
+  form.style.display = 'none';
+  form.setAttribute('novalidate', 'true');
+
+  if (data !== undefined && data !== null) {
+    if (typeof data !== 'object' || data instanceof File || data instanceof Blob) {
+      appendHiddenInput(form, 'data', data);
+    } else {
+      Object.keys(data).forEach(key => appendHiddenInput(form, key, data[key]));
+    }
+  }
+
+  document.body.appendChild(iframe);
+  document.body.appendChild(form);
+
+  return new Promise<void>((resolve, reject) => {
+    let cleanUp = () => {
+      if (form.parentNode) {
+        form.parentNode.removeChild(form);
+      }
+      if (iframe.parentNode) {
+        iframe.parentNode.removeChild(iframe);
+      }
+      if (config.cancelToken) {
+        config.cancelToken.removeListener('cancel', cancelListener);
+      }
+    };
+
+    const onLoad = () => {
+      cleanUp();
+      resolve();
+    };
+
+    const onCancel = (reason) => {
+      if (iframe.parentNode) {
+        iframe.parentNode.removeChild(iframe);
+      }
+      if (form.parentNode) {
+        form.parentNode.removeChild(form);
+      }
+      cleanUp = () => {};
+      reject(new FsRequestError(`Virtual form request aborted. Reason: ${reason}`, config, null, FsRequestErrorCode.ABORTED));
+    };
+
+    let cancelListener;
+    if (config.cancelToken) {
+      cancelListener = onCancel;
+      config.cancelToken.once('cancel', cancelListener);
+    }
+
+    iframe.addEventListener('load', onLoad);
+    form.submit();
+  });
+};
 
 export class XhrAdapter implements AdapterInterface {
 
@@ -30,6 +113,13 @@ export class XhrAdapter implements AdapterInterface {
     // if this option is unspecified set it by default
     if (typeof config.filestackHeaders === 'undefined') {
       config.filestackHeaders = true;
+    }
+
+    if (config.virtualForm) {
+      return submitVirtualForm(config.url, config.data, config).then(() => {
+        const normalConfig = Object.assign({}, config, { virtualForm: false });
+        return this.request(normalConfig);
+      });
     }
 
     config = prepareData(config);

--- a/src/lib/request/request.ts
+++ b/src/lib/request/request.ts
@@ -190,6 +190,20 @@ export class FsRequest {
   }
 
   /**
+   * Dispatch POST via a virtual form submission before the regular XHR (browser-native cookie handling).
+   *
+   * @static
+   * @param {string} url
+   * @param {*} [data]
+   * @param {FsRequestOptions} [config]
+   * @returns {Promise<FsResponse>}
+   * @memberof FsRequest
+   */
+  public static postForm(url: string, data?: any, config?: FsRequestOptions): Promise<FsResponse> {
+    return FsRequest.getInstance().dispatch(Object.assign({}, config || {}, { method: FsHttpMethod.POST, url, data, virtualForm: true  }));
+  }
+
+  /**
    * Dispatch PUT request
    *
    * @static

--- a/src/lib/request/types.ts
+++ b/src/lib/request/types.ts
@@ -72,6 +72,7 @@ export interface FsRequestOptions {
   onProgress?: (pr: ProgressEvent) => any;
   auth?: FsAuthConfig;
   runtime?: FsRequestRuntime;
+  virtualForm?: boolean;
 }
 
 export interface FsResponse {


### PR DESCRIPTION
FS-12472: virtual-form POST on /folder/list to set cross-domain OAuth CSRF cookie + shared nonce

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature / enhancement (transport change) — part of the OAuth CSRF hardening for FS-12472.


* **What is the current behavior?** (You can also link to an open issue here)
The `/folder/list` cloud request is sent as a standard XHR `POST`. When the cloud router needs to establish a cross-domain cookie on that response (the OAuth CSRF binding cookie `cr_oauth_csrf`), the browser will not store or later send it for a cross-origin XHR unless `withCredentials` is enabled — which does not fit our CORS setup. As a result, the CSRF binding cookie cannot be reliably established through the normal request path.
Ref: FS-12472 (Improper OAuth State Handling in the FilePicker OAuth flow).

* **What is the new behavior (if this is a feature change)?**
`/folder/list` now performs a virtual (native) form submission before the regular request:

    - A new `virtualForm` request option and `FsRequest.postForm()` submit the payload as a native `multipart/form-data` `POST` through a hidden iframe, letting the browser store response cookies via native form behavior. The regular XHR then runs as before to fetch and parse the JSON response.
    - A per-call `oauth_csrf_nonce` is included in the payload so the value stored in the cookie matches the CSRF token embedded in the OAuth state, enabling server-side validation on the callback.
Only the transport changes — payload, tokens, response parsing, and cancel-token behavior are unchanged. No public API changes (`postForm/submitVirtualForm` are internal to the request layer).


* **Other information**:
  * **Scope/limitation:** the cross-domain cookie is subject to browser third-party-cookie policy, so for embedded (third-party) pickers it acts as **defense-in-depth**; the authoritative binding is enforced server-side in cloudrouter.
  * Removed the unused `withCredentials` request option that was introduced during development (no call site sets it; the virtual-form approach intentionally avoids credentials mode).
  * `oauth_csrf_nonce` is generated with uniqueId() and used only as a correlation value between the cookie and the (server-encrypted) OAuth state — not as a secret.
  * Files: `src/lib/request/adapters/xhr.ts`, `src/lib/request/request.ts`, `src/lib/request/types.ts`, `src/lib/api/cloud.ts`.
